### PR TITLE
Add Broadway.get_rate_limiting/1

### DIFF
--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -926,6 +926,38 @@ defmodule Broadway do
   end
 
   @doc """
+  Gets the current values used for the producer rate limiting of the given pipeline.
+
+  Returns `{:ok, info}` if rate limiting is enabled for the given pipeline or
+  `{:error, reason}` if the given pipeline doesn't have rate limiting enabled.
+
+  The returned info is a map with the following keys:
+
+    * `:interval`
+    * `:allowed_messages`
+
+  See the `:rate_limiting` options in the module documentation for more information.
+
+  ## Examples
+
+      Broadway.get_rate_limiting(broadway)
+      #=> {:ok, %{allowed_messages: 2000, interval: 1000}}
+
+  """
+  @doc since: "0.6.0"
+  @spec get_rate_limiting(GenServer.server()) ::
+          {:ok, rate_limiting_info} | {:error, :rate_limiting_not_enabled}
+        when rate_limiting_info: %{
+               required(:interval) => non_neg_integer(),
+               required(:allowed_messages) => non_neg_integer()
+             }
+  def get_rate_limiting(broadway) do
+    with {:ok, rate_limiter_name} <- Server.get_rate_limiter(broadway) do
+      {:ok, Broadway.RateLimiter.get_rate_limiting(rate_limiter_name)}
+    end
+  end
+
+  @doc """
   Updates the producer rate limiting of the given pipeline at runtime.
 
   Supports the following options (see the `:rate_limiting` options in the module

--- a/lib/broadway/rate_limiter.ex
+++ b/lib/broadway/rate_limiter.ex
@@ -37,6 +37,10 @@ defmodule Broadway.RateLimiter do
     GenServer.call(rate_limiter, {:update_rate_limiting, opts})
   end
 
+  def get_rate_limiting(rate_limiter) do
+    GenServer.call(rate_limiter, :get_rate_limiting)
+  end
+
   @impl true
   def init({broadway_name, rate_limiting_opts, producers_names}) do
     interval = Keyword.fetch!(rate_limiting_opts, :interval)
@@ -68,6 +72,11 @@ defmodule Broadway.RateLimiter do
     }
 
     {:reply, :ok, state}
+  end
+
+  def handle_call(:get_rate_limiting, _from, state) do
+    %{interval: interval, allowed: allowed} = state
+    {:reply, %{interval: interval, allowed_messages: allowed}, state}
   end
 
   @impl true

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -2107,7 +2107,7 @@ defmodule BroadwayTest do
       assert timestamp3 < timestamp_cancel
     end
 
-    test "updating the rate limit at runtime" do
+    test "getting and updating the rate limit at runtime" do
       broadway_name = new_unique_name()
       test_pid = self()
 
@@ -2128,6 +2128,8 @@ defmodule BroadwayTest do
           context: %{handle_message: handle_message}
         )
 
+      assert Broadway.get_rate_limiting(broadway) == {:ok, %{allowed_messages: 1, interval: 5000}}
+
       send(
         get_producer(broadway_name),
         {:push_messages,
@@ -2144,6 +2146,7 @@ defmodule BroadwayTest do
       refute_received {:handle_message_called, _message, _timestamp}
 
       assert :ok = Broadway.update_rate_limiting(broadway, allowed_messages: 3)
+      assert Broadway.get_rate_limiting(broadway) == {:ok, %{allowed_messages: 3, interval: 5000}}
 
       send(get_rate_limiter(broadway_name), :reset_limit)
 


### PR DESCRIPTION
We have `Broadway.update_rate_limiting/2` so it might be nice to have a way to get the current rate limiting information out of a Broadway pipeline. In our system at work, we'd use this mostly during testing to assert that the rate limiting of our pipelines is right, but I can imagine this being possibly used to make dynamic decisions about the rate limiting. I'm not 100% convinced about this since it has the obvious race condition of getting you the rate limiting info at a given time with that info possibly changing soon after, but since it's so little code, I thought I'd just send a PR and kickstart the discussion here. Thoughts?