### PR TITLE
Add `start_link/1` to behaviour callbacks

### DIFF
--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -619,6 +619,12 @@ defmodule Broadway do
   @doc since: "0.5.0"
   @callback handle_failed(messages :: [Message.t()], context :: term) :: [Message.t()]
 
+  @doc """
+  Invoked by a supervisor to start a process.
+  """
+  @doc since: "0.6.0"
+  @callback start_link(arguments :: any()) :: GenServer.on_start()
+
   @optional_callbacks handle_batch: 4, handle_failed: 2
 
   @doc false
@@ -790,6 +796,7 @@ defmodule Broadway do
     * `:spawn_opt` - Optional. Overrides the top-level `:spawn_opt`.
 
   """
+  @spec start_link(module(), Keyword.t()) :: GenServer.on_start()
   def start_link(module, opts) do
     opts =
       case Keyword.pop(opts, :producers) do


### PR DESCRIPTION
Any module that is used in Broadway needs to implement `start_link/1`,
so I think it would be nice to add that as a required callback in the
behaviour definition.

I know that _technically_ this isn't part of `Broadway`'s responsibility
but instead called by the supervisor that starts the process, but since
all modules that implement the `Braodway` behaviour must define a
process that can be started, I think it would be clearer to readers that
the purpose of this function is to implement all the functions needed
to be used with `Broadway`.

I also noticed a missing typespec for `start_link/2`, so I added that as
well.