### PR TITLE
Docs: specify the latest release of broadway_rabbitmq

### DIFF
--- a/guides/examples/RabbitMQ.md
+++ b/guides/examples/RabbitMQ.md
@@ -67,7 +67,7 @@ Add `:broadway_rabbitmq` to the list of dependencies in `mix.exs`:
     def deps do
       [
         ...
-        {:broadway_rabbitmq, "~> 0.1.0"},
+        {:broadway_rabbitmq, "~> 0.6.0"},
       ]
     end
 


### PR DESCRIPTION
Ran into a little incompatibility bump while kicking the tires on Broadway. Perhaps there are API changes here that also need updated? I was able to get a producer / consumer working with the provided code, fwiw. 

Thanks for this library!