### PR TITLE
Add prepare messages callback

### DIFF
--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -595,12 +595,14 @@ defmodule Broadway do
     * `message` is the `Broadway.Message` struct to be processed.
     * `context` is the user defined data structure passed to `start_link/2`.
 
-  This is the place to do any pre-processing of the incoming messages, e.g.,
-  filtering/transforming messages according to some criteria.
+  This is the place to prepare and preload any information that will be used
+  by `handle_message/2`. For example, if you need to query the database,
+  instead of doing it once per message, you can do it on this callback.
 
-  This callback is optional. If present, it's called **before** the messages are passed to
-  `c:handle_message/3`. This gives you a change to do something with the messages before
-  they are handled, such as filtering or checking for idempotency.
+  The length of the list of messages received by this callback is based on
+  the `min_demand`/`max_demand` configuration in the processor. This callback
+  must always return all messages it receives, as `handle_message/2` is still
+  called individually for each message afterwards.
   """
   @callback prepare_messages(messages :: [Message.t()], context :: term) :: [Message.t()]
 

--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -588,6 +588,23 @@ defmodule Broadway do
   @type on_start() :: {:ok, pid()} | :ignore | {:error, {:already_started, pid()} | term()}
 
   @doc """
+  Invoked for preparing messages before handling (if defined).
+
+  It expects:
+
+    * `message` is the `Broadway.Message` struct to be processed.
+    * `context` is the user defined data structure passed to `start_link/2`.
+
+  This is the place to do any pre-processing of the incoming messages, e.g.,
+  filtering/transforming messages according to some criteria.
+
+  This callback is optional. If present, it's called **before** the messages are passed to
+  `c:handle_message/3`. This gives you a change to do something with the messages before
+  they are handled, such as filtering or checking for idempotency.
+  """
+  @callback prepare_messages(messages :: [Message.t()], context :: term) :: [Message.t()]
+
+  @doc """
   Invoked to handle/process individual messages sent from a producer.
 
   It receives:
@@ -695,7 +712,7 @@ defmodule Broadway do
   @doc since: "0.5.0"
   @callback handle_failed(messages :: [Message.t()], context :: term) :: [Message.t()]
 
-  @optional_callbacks handle_batch: 4, handle_failed: 2
+  @optional_callbacks prepare_messages: 2, handle_batch: 4, handle_failed: 2
 
   @doc false
   defmacro __using__(opts) do

--- a/lib/broadway/processor.ex
+++ b/lib/broadway/processor.ex
@@ -49,7 +49,9 @@ defmodule Broadway.Processor do
     start_time = System.monotonic_time()
     emit_start_event(state.name, start_time, messages)
 
-    {successful_messages, failed_messages} = handle_messages(messages, [], [], state)
+    {prepared_messages, prepared_failed_messages} = maybe_prepare_messages(messages, state)
+    {successful_messages, failed_messages} = handle_messages(prepared_messages, [], [], state)
+    failed_messages = failed_messages ++ prepared_failed_messages
 
     {successful_messages_to_forward, successful_messages_to_ack} =
       case state do
@@ -112,6 +114,31 @@ defmodule Broadway.Processor do
     :telemetry.execute([:broadway, :processor, :stop], measurements, metadata)
   end
 
+  defp maybe_prepare_messages(messages, state) do
+    %{module: module, context: context, batchers: batchers} = state
+
+    if function_exported?(module, :prepare_messages, 2) and messages != [] do
+      try do
+        messages
+        |> module.prepare_messages(context)
+        |> Enum.map(&validate_message(&1, batchers, "prepare_messages/2"))
+        |> split_by_status([], [])
+      catch
+        kind, reason ->
+          reason = Exception.normalize(kind, reason, __STACKTRACE__)
+
+          Logger.error(Exception.format(kind, reason, __STACKTRACE__),
+            crash_reason: Acknowledger.crash_reason(kind, reason, __STACKTRACE__)
+          )
+
+          messages = Enum.map(messages, &%{&1 | status: {kind, reason, __STACKTRACE__}})
+          {[], messages}
+      end
+    else
+      {messages, []}
+    end
+  end
+
   defp handle_messages([message | messages], successful, failed, state) do
     %{
       module: module,
@@ -127,7 +154,7 @@ defmodule Broadway.Processor do
     try do
       message =
         module.handle_message(processor_key, message, context)
-        |> validate_message(batchers)
+        |> validate_message(batchers, "handle_message/3")
 
       emit_message_stop_event(start_time, processor_key, name, message)
       message
@@ -211,7 +238,7 @@ defmodule Broadway.Processor do
     :telemetry.execute([:broadway, :processor, :message, :exception], measurements, metadata)
   end
 
-  defp validate_message(%Message{batcher: batcher, status: status} = message, batchers) do
+  defp validate_message(%Message{batcher: batcher, status: status} = message, batchers, _fn_name) do
     if status == :ok and batchers != :none and batcher not in batchers do
       raise "message was set to unknown batcher #{inspect(batcher)}. " <>
               "The known batchers are #{inspect(batchers)}"
@@ -220,7 +247,19 @@ defmodule Broadway.Processor do
     message
   end
 
-  defp validate_message(message, _batchers) do
-    raise "expected a Broadway.Message from handle_message/3, got #{inspect(message)}"
+  defp validate_message(message, _batchers, fn_name) do
+    raise "expected a Broadway.Message from #{fn_name}, got #{inspect(message)}"
+  end
+
+  defp split_by_status([], successful, failed) do
+    {Enum.reverse(successful), Enum.reverse(failed)}
+  end
+
+  defp split_by_status([%Message{status: :ok} = message | rest], successful, failed) do
+    split_by_status(rest, [message | successful], failed)
+  end
+
+  defp split_by_status([%Message{} = message | rest], successful, failed) do
+    split_by_status(rest, successful, [message | failed])
   end
 end


### PR DESCRIPTION
This callback will allow preparing messages before sending to
handle_message.

Related to issue: https://github.com/dashbitco/broadway/issues/172