### PR TITLE
Add `:telemetry_prefix` as configuration option

### DIFF
--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -903,8 +903,18 @@ defmodule Broadway do
         opts =
           opts
           |> carry_over_one(:producer, [:hibernate_after, :spawn_opt])
-          |> carry_over_many(:processors, [:partition_by, :hibernate_after, :spawn_opt, :telemetry_prefix])
-          |> carry_over_many(:batchers, [:partition_by, :hibernate_after, :spawn_opt, :telemetry_prefix])
+          |> carry_over_many(:processors, [
+            :partition_by,
+            :hibernate_after,
+            :spawn_opt,
+            :telemetry_prefix
+          ])
+          |> carry_over_many(:batchers, [
+            :partition_by,
+            :hibernate_after,
+            :spawn_opt,
+            :telemetry_prefix
+          ])
 
         Server.start_link(module, opts)
     end

--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -903,8 +903,8 @@ defmodule Broadway do
         opts =
           opts
           |> carry_over_one(:producer, [:hibernate_after, :spawn_opt])
-          |> carry_over_many(:processors, [:partition_by, :hibernate_after, :spawn_opt])
-          |> carry_over_many(:batchers, [:partition_by, :hibernate_after, :spawn_opt])
+          |> carry_over_many(:processors, [:partition_by, :hibernate_after, :spawn_opt, :telemetry_prefix])
+          |> carry_over_many(:batchers, [:partition_by, :hibernate_after, :spawn_opt, :telemetry_prefix])
 
         Server.start_link(module, opts)
     end
@@ -1129,6 +1129,7 @@ defmodule Broadway do
       max_seconds: [type: :pos_integer, default: 5],
       resubscribe_interval: [type: :non_neg_integer, default: 100],
       context: [type: :any, default: :context_not_set],
+      telemetry_prefix: [type: :any],
       producer: [
         required: true,
         type: :non_empty_keyword_list,
@@ -1167,7 +1168,8 @@ defmodule Broadway do
             max_demand: [type: :non_neg_integer, default: 10],
             partition_by: [type: {:fun, 1}],
             spawn_opt: [type: :keyword_list],
-            hibernate_after: [type: :pos_integer]
+            hibernate_after: [type: :pos_integer],
+            telemetry_prefix: [type: :any]
           ]
         ]
       ],
@@ -1186,7 +1188,8 @@ defmodule Broadway do
             batch_timeout: [type: :pos_integer, default: 1000],
             partition_by: [type: {:fun, 1}],
             spawn_opt: [type: :keyword_list],
-            hibernate_after: [type: :pos_integer]
+            hibernate_after: [type: :pos_integer],
+            telemetry_prefix: [type: :any]
           ]
         ]
       ],

--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -1129,7 +1129,6 @@ defmodule Broadway do
       max_seconds: [type: :pos_integer, default: 5],
       resubscribe_interval: [type: :non_neg_integer, default: 100],
       context: [type: :any, default: :context_not_set],
-      telemetry_prefix: [type: :any],
       producer: [
         required: true,
         type: :non_empty_keyword_list,
@@ -1194,6 +1193,7 @@ defmodule Broadway do
         ]
       ],
       partition_by: [type: {:fun, 1}],
+      telemetry_prefix: [type: :any],
       spawn_opt: [type: :keyword_list],
       hibernate_after: [type: :pos_integer, default: 15_000]
     ]

--- a/lib/broadway/consumer.ex
+++ b/lib/broadway/consumer.ex
@@ -75,7 +75,15 @@ defmodule Broadway.Consumer do
         )
     end
 
-    emit_stop_event(state.telemetry_prefix, state.name, start_time, successful_messages, failed_messages, batch_info)
+    emit_stop_event(
+      state.telemetry_prefix,
+      state.name,
+      start_time,
+      successful_messages,
+      failed_messages,
+      batch_info
+    )
+
     {:noreply, [], state}
   end
 

--- a/lib/broadway/processor.ex
+++ b/lib/broadway/processor.ex
@@ -20,10 +20,6 @@ defmodule Broadway.Processor do
   def init(args) do
     Process.flag(:trap_exit, true)
     type = args[:type]
-    telemetry_prefix =
-      args[:processor_config]
-      |> Keyword.get(:telemetry_prefix, [])
-      |> Enum.concat([:broadway, :processor])
 
     state = %{
       name: args[:name],
@@ -32,7 +28,7 @@ defmodule Broadway.Processor do
       context: args[:context],
       processor_key: args[:processor_key],
       batchers: args[:batchers],
-      telemetry_prefix: telemetry_prefix
+      telemetry_prefix: extract_telemetry_prefix(args)
     }
 
     case type do
@@ -232,5 +228,12 @@ defmodule Broadway.Processor do
 
   defp validate_message(message, _batchers) do
     raise "expected a Broadway.Message from handle_message/3, got #{inspect(message)}"
+  end
+
+  defp extract_telemetry_prefix(args) do
+    args
+    |> Keyword.merge(args[:processor_config])
+    |> Keyword.get(:telemetry_prefix, [])
+    |> Enum.concat([:broadway, :processor])
   end
 end

--- a/test/broadway/batcher_test.exs
+++ b/test/broadway/batcher_test.exs
@@ -22,4 +22,27 @@ defmodule Broadway.BatcherTest do
     %{state: state} = :sys.get_state(pid)
     assert state.subscription_options[:max_demand] == 123
   end
+
+  test "telemtry_prefix is prepends to the event name" do
+    {:ok, pid} =
+      Broadway.Batcher.start_link(
+        [
+          module: __MODULE__,
+          context: %{},
+          type: :producer_consumer,
+          terminator: __MODULE__,
+          resubscribe: :never,
+          batcher: :default,
+          processors: [:some_processor],
+          batch_size: 123,
+          batch_timeout: 1000,
+          partition: 0,
+          telemetry_prefix: [:my_app, :example]
+        ],
+        []
+      )
+
+    %{state: state} = :sys.get_state(pid)
+    assert state.telemetry_prefix == [:my_app, :example, :broadway, :batcher]
+  end
 end

--- a/test/broadway/processor_test.exs
+++ b/test/broadway/processor_test.exs
@@ -22,4 +22,49 @@ defmodule Broadway.ProcessorTest do
     assert state.subscription_options[:min_demand] == 3
     assert state.subscription_options[:max_demand] == 6
   end
+
+  describe "telemetry_prefix" do
+    test "sets prefix at top level" do
+      {:ok, pid} =
+        Broadway.Processor.start_link(
+          [
+            module: __MODULE__,
+            context: %{},
+            type: :producer_consumer,
+            terminator: __MODULE__,
+            resubscribe: :never,
+            processor_config: [min_demand: 3],
+            producers: [:sample],
+            partition: 0,
+            dispatcher: GenStage.DemandDispatcher,
+            telemetry_prefix: [:my_app, :example]
+          ],
+          []
+        )
+
+      %{state: state} = :sys.get_state(pid)
+      assert state.telemetry_prefix == [:my_app, :example, :broadway, :processor]
+    end
+
+    test "overrides telemetry prefix at processor level" do
+      {:ok, pid} =
+        Broadway.Processor.start_link(
+          [
+            module: __MODULE__,
+            context: %{},
+            type: :producer_consumer,
+            terminator: __MODULE__,
+            resubscribe: :never,
+            processor_config: [telemetry_prefix: [:my_app, :example]],
+            producers: [:sample],
+            partition: 0,
+            dispatcher: GenStage.DemandDispatcher
+          ],
+          []
+        )
+
+      %{state: state} = :sys.get_state(pid)
+      assert state.telemetry_prefix == [:my_app, :example, :broadway, :processor]
+    end
+  end
 end


### PR DESCRIPTION
We are wanting to run multiple Broadway services in one of our applications, but in order to configure it well, we need to be able to get a read on how long processing takes in the different stages. We can't do that from the generic `[:broadway, :processor, :stop]`; we need something like `[:my_app, :my_aspect, :broadway, :processor, :stop]`. This PR attempts to add that.

- Adds the `:telemetry_prefix` option at the top level, as well as at the `:processors` and `:batchers` level
- Adding `:telemetry_prefix` at the lower levels overrides the global option
- Added tests (or attempted to)

I will add documentation if the general idea is approved.