### PR TITLE
Clarify effect of some concurrency settings

### DIFF
--- a/guides/examples/Amazon SQS.md
+++ b/guides/examples/Amazon SQS.md
@@ -196,7 +196,12 @@ available for every set of producers, processors and batchers, among with
 of flexibility.
 
 The `concurrency` option controls the concurrency level in each layer of
-the pipeline. Here's an example on how you could tune them according to
+the pipeline.
+See the notes on [`Producer concurrency`](https://hexdocs.pm/broadway/Broadway.html#module-producer-concurrency)
+and [`Batcher concurrency`](https://hexdocs.pm/broadway/Broadway.html#module-batcher-concurrency)
+for details.
+
+Here's an example on how you could tune them according to
 your needs.
 
     defmodule MyBroadway do

--- a/guides/examples/Apache Kafka.md
+++ b/guides/examples/Apache Kafka.md
@@ -233,6 +233,9 @@ they need and how much IO work is going to take place, you might need completely
 different values to optimize the flow of your pipeline. The `concurrency` option
 available for every set of producers, processors and batchers, along with
 `batch_size` and `batch_timeout` can give you a great deal of flexibility.
+See the notes on [`Producer concurrency`](https://hexdocs.pm/broadway/Broadway.html#module-producer-concurrency)
+and [`Batcher concurrency`](https://hexdocs.pm/broadway/Broadway.html#module-batcher-concurrency)
+for details.
 
 By setting the `concurrency` option, you define the number of concurrent process
 that will be started by Broadway, allowing you to have full control over the

--- a/guides/examples/Google Cloud PubSub.md
+++ b/guides/examples/Google Cloud PubSub.md
@@ -247,7 +247,12 @@ available for every set of producers, processors and batchers, among with
 of flexibility.
 
 The `concurrency` option controls the concurrency level in each layer of
-the pipeline. Here's an example on how you could tune them according to
+the pipeline.
+See the notes on [`Producer concurrency`](https://hexdocs.pm/broadway/Broadway.html#module-producer-concurrency)
+and [`Batcher concurrency`](https://hexdocs.pm/broadway/Broadway.html#module-batcher-concurrency)
+for details.
+
+Here's an example on how you could tune them according to
 your needs.
 
     defmodule MyBroadway do

--- a/guides/examples/RabbitMQ.md
+++ b/guides/examples/RabbitMQ.md
@@ -101,7 +101,7 @@ Assuming we want to consume messages from a queue called
                 prefetch_count: 50,
               ]
             },
-            concurrency: 2
+            concurrency: 1
           ],
           processors: [
             default: [
@@ -254,21 +254,18 @@ available for every set of producers, processors and batchers, among with
 `max_demand`, `batch_size`, and `batch_timeout` can give you a great deal
 of flexibility. The `concurrency` option controls the concurrency level in
 each layer of the pipeline.
+See the notes on [`Producer concurrency`](https://hexdocs.pm/broadway/Broadway.html#module-producer-concurrency)
+and [`Batcher concurrency`](https://hexdocs.pm/broadway/Broadway.html#module-batcher-concurrency)
+for details.
 
-Another important option to take into account is the `:prefetch_count`. Note
-that unlike the RabittMQ client that has a default `:prefetch_count` = 0, which
-disables back-pressure, BroadwayRabbitMQ overwrite the default value to `50`
-enabling the back-pressure mechanism. In order to keep your pipeline fully
-busy, you likely want to set it to `num_servers * num_processors * max_demand`.
-However, a large `prefetch_count` may mean messages sit idle on the processor
-inbox, leading to worse distribution. So in some cases you rather want to reduce
-the number of processors and `max_demand` rather than increase `prefetch_count`.
-You can see more details in the ["Back-pressure and :prefetch_count"](https://hexdocs.pm/broadway_rabbitmq/BroadwayRabbitMQ.Producer.html#module-back-pressure-and-prefetch_count)
-section of the `BroadwayRabbitMQ` documentation.
+Another important option to take into account is the `:prefetch_count`.
+RabbitMQ will continually push new messages to Broadway as it receives them.
+The `:prefetch_count` setting provides back-pressure by instructing RabbitMQ to [limit the number of unacknowledged messages a consumer will have at a given moment](https://www.rabbitmq.com/consumer-prefetch.html).
+See the ["Back-pressure and :prefetch_count"](https://hexdocs.pm/broadway_rabbitmq/BroadwayRabbitMQ.Producer.html#module-back-pressure-and-prefetch_count)
+section of the `BroadwayRabbitMQ` documentation for details.
 
 In order to get a good set of configurations for your pipeline, it's
 important to respect the limitations of the servers you're running,
 as well as the limitations of the services you're providing/consuming
 data to/from. Broadway comes with telemetry, so you can measure your
 pipeline and help ensure your changes are effective.
-

--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -293,6 +293,9 @@ defmodule Broadway do
 
   ## Producer concurrency
 
+  Setting producer concurrency is a tradeoff between latency and internal
+  queueing.
+
   For efficiency, you should generally limit the amount of internal queueing.
   Whenever additional messages are sitting in a busy processor's mailbox, they
   can't be delivered to another processor which may be available or become
@@ -305,11 +308,20 @@ defmodule Broadway do
   whatever the specific producer does) and give them to the processor. So the
   processor may receive `max_demand * <producer concurrency>` messages.
 
-  Setting producer `concurrency: 1` will reduce internal queueing, so this is
-  the recommended setting to start with. **Only increase producer concurrency
-  if you can measure performance improvements in your system**. Adding another
-  single-producer pipeline, or another node running the pipeline, are other
-  ways you may consider to increase throughput.
+  Setting producer `concurrency: 1` will reduce internal queueing. This is
+  likely a good choice for producers which take minimal time to produce a
+  messsage, such as `BroadwayRabbitMQ`, which receives messages as they are
+  pushed by RabbitMQ and can specify how many to prefetch.
+
+  On the other hand, when using a producer such as `BroadwaySQS` which must
+  make a network round trip to fetch from an external source, it may be better
+  to use multiple producers and accept some internal queueing to avoid having
+  fetch messages whenever there is new demand.
+
+  Measure your system to decide which setting is most appropriate.
+
+  Adding another single-producer pipeline, or another node running the
+  pipeline, are other ways you may consider to increase throughput.
 
   ## Batcher concurrency
 


### PR DESCRIPTION
- Add notes on how producer concurrency may affect internal queueing and
  on how messages are delivered to concurrent batchers
- Link from each producer-specific guide to those sections
- Update RabbitMQ example to use one producer, as in the
  BroadwayRabbitMQ docs