### PR TITLE
RateLimiter ETS to atomics

### DIFF
--- a/lib/broadway/topology.ex
+++ b/lib/broadway/topology.ex
@@ -56,7 +56,7 @@ defmodule Broadway.Topology do
       batchers_names:
         Enum.map(config.batchers_config, &process_name(config.name, "Batcher", elem(&1, 0))),
       rate_limiter_name:
-        config.producer_config[:rate_limiting] && RateLimiter.table_name(opts[:name])
+        config.producer_config[:rate_limiting] && RateLimiter.rate_limiter_name(opts[:name])
     })
 
     {:ok,

--- a/lib/broadway/topology/rate_limiter.ex
+++ b/lib/broadway/topology/rate_limiter.ex
@@ -1,9 +1,7 @@
 defmodule Broadway.Topology.RateLimiter do
-  # TODO: Use :counters once we require Erlang/OTP 22+
   @moduledoc false
 
   use GenServer
-  @row_name :rate_limit_counter
 
   def start_link(opts) do
     case Keyword.fetch!(opts, :rate_limiting) do
@@ -16,20 +14,20 @@ defmodule Broadway.Topology.RateLimiter do
         name = Keyword.fetch!(opts, :name)
         producers_names = Keyword.fetch!(opts, :producers_names)
         args = {name, rate_limiting_opts, producers_names}
-        GenServer.start_link(__MODULE__, args, name: table_name(name))
+        GenServer.start_link(__MODULE__, args, name: rate_limiter_name(name))
     end
   end
 
-  def rate_limit(table_name, amount)
-      when is_atom(table_name) and is_integer(amount) and amount > 0 do
-    :ets.update_counter(table_name, @row_name, -amount)
+  def rate_limit(counter, amount)
+      when is_reference(counter) and is_integer(amount) and amount > 0 do
+    :atomics.sub_get(counter, 1, amount)
   end
 
-  def get_currently_allowed(table_name) when is_atom(table_name) do
-    :ets.lookup_element(table_name, @row_name, 2)
+  def get_currently_allowed(counter) when is_reference(counter) do
+    :atomics.get(counter, 1)
   end
 
-  def table_name(broadway_name) when is_atom(broadway_name) do
+  def rate_limiter_name(broadway_name) when is_atom(broadway_name) do
     Module.concat(broadway_name, RateLimiter)
   end
 
@@ -41,13 +39,17 @@ defmodule Broadway.Topology.RateLimiter do
     GenServer.call(rate_limiter, :get_rate_limiting)
   end
 
+  def get_rate_limiter_ref(rate_limiter) do
+    GenServer.call(rate_limiter, :get_rate_limiter_ref)
+  end
+
   @impl true
-  def init({broadway_name, rate_limiting_opts, producers_names}) do
+  def init({_broadway_name, rate_limiting_opts, producers_names}) do
     interval = Keyword.fetch!(rate_limiting_opts, :interval)
     allowed = Keyword.fetch!(rate_limiting_opts, :allowed_messages)
 
-    table = :ets.new(table_name(broadway_name), [:named_table, :public, :set])
-    :ets.insert(table, {@row_name, allowed})
+    counter = :atomics.new(1, [])
+    :atomics.put(counter, 1, allowed)
 
     _ = schedule_next_reset(interval)
 
@@ -55,7 +57,7 @@ defmodule Broadway.Topology.RateLimiter do
       interval: interval,
       allowed: allowed,
       producers_names: producers_names,
-      table: table
+      counter: counter
     }
 
     {:ok, state}
@@ -79,12 +81,16 @@ defmodule Broadway.Topology.RateLimiter do
     {:reply, %{interval: interval, allowed_messages: allowed}, state}
   end
 
+  def handle_call(:get_rate_limiter_ref, _from, %{counter: counter} = state) do
+    {:reply, counter, state}
+  end
+
   @impl true
   def handle_info(:reset_limit, state) do
-    %{producers_names: producers_names, interval: interval, allowed: allowed, table: table} =
+    %{producers_names: producers_names, interval: interval, allowed: allowed, counter: counter} =
       state
 
-    true = :ets.insert(table, {@row_name, allowed})
+    :atomics.put(counter, 1, allowed)
 
     for name <- producers_names,
         pid = Process.whereis(name),


### PR DESCRIPTION
Switching the counter implementation in RateLimiter from ETS to atomics given that it looks like OTP 21.3+ is a requirement for Broadway (https://github.com/dashbitco/broadway/blob/master/lib/broadway/topology.ex#L40-L44).

I also opted for atomics as opposed to counters given that there are no `{sub,add}_get` BIFs in OTP for counters and I did not want to introduce a read after write issue with `RateLimiter.rate_limit/2` function.

Thanks in advance for any feedback!