### PR TITLE
Added supervisor init telemetry event

### DIFF
--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -504,8 +504,8 @@ defmodule Broadway do
 
   Broadway currently exposes following Telemetry events:
 
-    * `[:broadway, :supervisor, :init]` - Dispatched when the supervision tree
-      for a Broadway module is initialized. The config key in the metadata
+    * `[:broadway, :topology, :init]` - Dispatched when the topology for
+      a Broadway pipeline is initialized. The config key in the metadata
       contains the configuration options that were provided to
       `Broadway.start_link/2`.
 

--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -504,6 +504,14 @@ defmodule Broadway do
 
   Broadway currently exposes following Telemetry events:
 
+    * `[:broadway, :supervisor, :init]` - Dispatched when the supervision tree
+      for a Broadway module is initialized. The config key in the metadata
+      contains the configuration options that were provided to
+      `Broadway.start_link/2`.
+
+      * Measurement: `%{time: System.monotonic_time}`
+      * Metadata: `%{supervision: pid(), config: keyword()}`
+
     * `[:broadway, :processor, :start]` - Dispatched by a Broadway processor
       before the optional `c:prepare_messages/2`
 

--- a/lib/broadway/topology.ex
+++ b/lib/broadway/topology.ex
@@ -165,7 +165,7 @@ defmodule Broadway.Topology do
       supervisor_pid: supervisor_pid
     }
 
-    :telemetry.execute([:broadway, :supervisor, :init], measurements, metadata)
+    :telemetry.execute([:broadway, :topology, :init], measurements, metadata)
   end
 
   defp start_options(name, config) do

--- a/lib/broadway/topology.ex
+++ b/lib/broadway/topology.ex
@@ -50,6 +50,11 @@ defmodule Broadway.Topology do
     config = init_config(module, opts)
     {:ok, supervisor_pid} = start_supervisor(child_specs, config, opts)
 
+    :telemetry.execute([:broadway, :supervisor, :init], %{}, %{
+      config: config,
+      supervisor_pid: supervisor_pid
+    })
+
     :persistent_term.put(config.name, %{
       context: config.context,
       producer_names: process_names(config.name, "Producer", config.producer_config),

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -237,7 +237,23 @@ defmodule BroadwayTest do
 
       assert_receive {:telemetry_event, [:broadway, :supervisor, :init], %{},
                       %{config: config, supervisor_pid: supervisor_pid}}
-                     when is_pid(supervisor_pid) and is_map(config)
+                     when is_pid(supervisor_pid)
+
+      Enum.each(
+        [
+          :batchers_config,
+          :name,
+          :max_restarts,
+          :max_seconds,
+          :module,
+          :processors_config,
+          :producer_config,
+          :shutdown
+        ],
+        fn key ->
+          assert Map.has_key?(config, key)
+        end
+      )
     end
 
     test "default number of processors is schedulers_online * 2" do

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -217,7 +217,7 @@ defmodule BroadwayTest do
 
       :telemetry.attach(
         "#{test}",
-        [:broadway, :supervisor, :init],
+        [:broadway, :topology, :init],
         fn name, measurements, metadata, _ ->
           send(self, {:telemetry_event, name, measurements, metadata})
         end,
@@ -235,7 +235,7 @@ defmodule BroadwayTest do
       assert get_n_producers(broadway) == 3
       assert length(Broadway.producer_names(broadway)) == 3
 
-      assert_receive {:telemetry_event, [:broadway, :supervisor, :init], %{},
+      assert_receive {:telemetry_event, [:broadway, :topology, :init], %{},
                       %{config: config, supervisor_pid: supervisor_pid}}
                      when is_pid(supervisor_pid)
 

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -241,17 +241,12 @@ defmodule BroadwayTest do
 
       Enum.each(
         [
-          :batchers_config,
           :name,
-          :max_restarts,
-          :max_seconds,
-          :module,
-          :processors_config,
-          :producer_config,
-          :shutdown
+          :producer,
+          :processors
         ],
         fn key ->
-          assert Map.has_key?(config, key)
+          assert Keyword.has_key?(config, key)
         end
       )
     end


### PR DESCRIPTION
I am currently working on the PromEx Broadway plugin (https://github.com/akoutmos/prom_ex/pull/39) and would like to incorporate some of the configuration details into the Broadway Grafana dashboard. Thoughts on surfacing the config from the Topology module after the supervisor is started?

If you are okay with this approach I will go through and add the necessary documentation to the telemetry events. Thanks in advance!