### PR TITLE
Added proposed ack configuration for Broadway.test_message/3 and test_batch/3

### DIFF
--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -890,6 +890,14 @@ defmodule Broadway do
       message. This can be used, for example, when testing
       `BroadwayRabbitMQ.Producer`.
 
+    * `:acknowledger_module` - optionally a module implementing a
+      `Broadway.Acknowledger` behaviour. It will be attached to the message
+      and `c:Broadway.Acknowledger.ack/3` of that module will be invoked
+      instead of the `Broadway.CallerAcknowledger`.
+
+    * `:acknowledger_data` - optionally a term that will be attached to
+      acknowledger field in the message.
+
   ## Examples
 
   For example, in your tests, you may do:
@@ -931,6 +939,14 @@ defmodule Broadway do
       message. This can be used, for example, when testing
       `BroadwayRabbitMQ.Producer`.
 
+    * `:acknowledger_module` - optionally a module implementing a
+      `Broadway.Acknowledger` behaviour. It will be attached to the message
+      and `c:Broadway.Acknowledger.ack/3` of that module will be invoked
+      instead of the `Broadway.CallerAcknowledger`.
+
+    * `:acknowledger_data` - optionally a term that will be attached to
+      acknowledger field in the message.
+
   ## Examples
 
   For example, in your tests, you may do:
@@ -951,8 +967,10 @@ defmodule Broadway do
 
     ref = make_ref()
 
-    default_ack = {Broadway.CallerAcknowledger, {self(), ref}, :ok}
-    ack = Keyword.get(opts, :ack, default_ack)
+    ack_module = Keyword.get(opts, :acknowledger_module, Broadway.CallerAcknowledger)
+    ack_data = Keyword.get(opts, :acknowledger_data, :ok)
+
+    ack = {ack_module, {self(), ref}, ack_data}
 
     messages =
       Enum.map(

--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -950,7 +950,9 @@ defmodule Broadway do
     metadata = Map.new(Keyword.get(opts, :metadata, []))
 
     ref = make_ref()
-    ack = {Broadway.CallerAcknowledger, {self(), ref}, :ok}
+
+    default_ack = {Broadway.CallerAcknowledger, {self(), ref}, :ok}
+    ack = Keyword.get(opts, :ack, default_ack)
 
     messages =
       Enum.map(

--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -892,8 +892,8 @@ defmodule Broadway do
 
     * `:acknowledger` - optionally a function that generates `ack` fields of
     `Broadway.Message.t()` that is sent. This function should have following
-    spec `(data :: term, {pid, reference()}) :: {module, ack_ref :: term,
-    data :: term}`.
+    spec `(data :: term, {pid, reference()} -> {module, ack_ref :: term,
+    data :: term})`.
 
   ## Examples
 
@@ -943,8 +943,8 @@ defmodule Broadway do
 
     * `:acknowledger` - optionally a function that generates `ack` fields of
     `Broadway.Message.t()` that is sent. This function should have following
-    spec `(data :: term, {pid, reference()}) :: {module, ack_ref :: term,
-    data :: term}`. See `test_message/3` for an example.
+    spec `(data :: term, {pid, reference()} -> {module, ack_ref :: term,
+    data :: term})`. See `test_message/3` for an example.
 
   ## Examples
 

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -555,8 +555,7 @@ defmodule BroadwayTest do
       end
 
       opts = [
-        acknowledger_module: AckMod,
-        acknowledger_data: :data
+        acknowledger: fn _data, ack_ref -> {AckMod, ack_ref, :data} end
       ]
 
       ref = Broadway.test_message(broadway, :message, opts)


### PR DESCRIPTION
In our app we redefined mentioned functions to enable using different Acknowledgers. I think that this is a very small change but can be actually useful for others. I do think CallerAcknowledger is totally good enough for testing only, but we do have a customer acknowledger that we use for :dev level dirty debugging.

I decided to commit only changes needed to validate and demonstrate the idea. If I will get any positive feedback on this PR I will write the necessary documentation and tests.