### PR TITLE
Fix Logger crash_reason for Erlang errors

### DIFF
--- a/lib/broadway/acknowledger.ex
+++ b/lib/broadway/acknowledger.ex
@@ -84,7 +84,7 @@ defmodule Broadway.Acknowledger do
   @doc false
   # Builds a crash reason used in Logger reporting.
   def crash_reason(:throw, reason, stack), do: {{:nocatch, reason}, stack}
-  def crash_reason(:error, reason, stack), do: {reason, stack}
+  def crash_reason(:error, reason, stack), do: {Exception.normalize(:error, reason, stack), stack}
   def crash_reason(:exit, reason, stack), do: {reason, stack}
 
   # Used by the processor and the batcher to maybe call c:handle_failed/2

--- a/test/broadway/acknowledger_test.exs
+++ b/test/broadway/acknowledger_test.exs
@@ -1,0 +1,39 @@
+defmodule Broadway.AcknowledgerTest do
+  use ExUnit.Case
+
+  describe "crash_reason/3" do
+    test "exceptions" do
+      {kind, reason, stack} = kind_reason_stack(fn -> raise "oops" end)
+
+      assert {%RuntimeError{message: "oops"}, [_ | _]} =
+               Broadway.Acknowledger.crash_reason(kind, reason, stack)
+    end
+
+    test "exits" do
+      {kind, reason, stack} = kind_reason_stack(fn -> exit(:fatal_error) end)
+
+      assert {:fatal_error, [_ | _]} = Broadway.Acknowledger.crash_reason(kind, reason, stack)
+    end
+
+    test "throws" do
+      {kind, reason, stack} = kind_reason_stack(fn -> throw(:basketball) end)
+
+      assert {{:nocatch, :basketball}, [_ | _]} =
+               Broadway.Acknowledger.crash_reason(kind, reason, stack)
+    end
+
+    test "Erlang errors" do
+      {kind, reason, stack} = kind_reason_stack(fn -> :erlang.error(:boom) end)
+
+      assert {%ErlangError{original: :boom}, [_ | _]} =
+               Broadway.Acknowledger.crash_reason(kind, reason, stack)
+    end
+  end
+
+  defp kind_reason_stack(fun) do
+    fun.()
+  catch
+    kind, reason ->
+      {kind, reason, __STACKTRACE__}
+  end
+end


### PR DESCRIPTION
"Erlang errors" in `Broadway` callbacks were being reported as exits in the `Logger` metadata.

i.e.:

```elixir

# crashes in callbacks generated by something like this:
:erlang.error(:something)

# are currently passed in Logger metadata like exits, i.e.:
Logger.error("...", crash_reason: {:something, __STACKTRACE__})

# this PR fixes it so that they are normalized first:
Logger.error("...", crash_reason: {%ErlangError{original: :something}, __STACKTRACE__})
```

Questions:

- want me to update `CHANGELOG.md` for this?
- is there a better place for the tests?