### PR TITLE
Change `:persistent_term` key use namespace

### DIFF
--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -958,19 +958,9 @@ defmodule Broadway do
   It's important to notice that no order is guaranteed.
   """
   def all do
-    Enum.reduce(:persistent_term.get(), [], fn key_value, names ->
-      case key_value do
-        {{Broadway, name}, %Broadway.Topology.Config{}} ->
-          if Process.whereis(name) do
-            [name | names]
-          else
-            names
-          end
-
-        _ ->
-          names
-      end
-    end)
+    for {{Broadway, name}, %Broadway.Topology.Config{}} <- :persistent_term.get(),
+        Process.whereis(name),
+        do: name
   end
 
   @doc """

--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -953,6 +953,27 @@ defmodule Broadway do
   end
 
   @doc """
+  Returns all running Broadway names.
+
+  It's important to notice that no order is guaranteed.
+  """
+  def all do
+    Enum.reduce(:persistent_term.get(), [], fn key_value, names ->
+      case key_value do
+        {{Broadway, name}, %Broadway.Topology.Config{}} ->
+          if Process.whereis(name) do
+            [name | names]
+          else
+            names
+          end
+
+        _ ->
+          names
+      end
+    end)
+  end
+
+  @doc """
   Sends a list of `Broadway.Message`s to the Broadway pipeline.
 
   The producer is randomly chosen among all sets of producers/stages.

--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -957,8 +957,8 @@ defmodule Broadway do
 
   It's important to notice that no order is guaranteed.
   """
-  def all do
-    for {{Broadway, name}, %Broadway.Topology.Config{}} <- :persistent_term.get(),
+  def all_running do
+    for {{Broadway, name}, %Broadway.Topology{}} <- :persistent_term.get(),
         Process.whereis(name),
         do: name
   end

--- a/lib/broadway/topology.ex
+++ b/lib/broadway/topology.ex
@@ -11,6 +11,12 @@ defmodule Broadway.Topology do
     RateLimiter
   }
 
+  defmodule Config do
+    @moduledoc false
+
+    defstruct [:context, :topology, :producer_names, :batchers_names, :rate_limiter_name]
+  end
+
   def start_link(module, opts) do
     GenServer.start_link(__MODULE__, {module, opts}, opts)
   end
@@ -32,7 +38,8 @@ defmodule Broadway.Topology do
   end
 
   defp config(server) do
-    :persistent_term.get(server, nil) || exit({:noproc, {__MODULE__, :config, [server]}})
+    :persistent_term.get({Broadway, server}, nil) ||
+      exit({:noproc, {__MODULE__, :config, [server]}})
   end
 
   ## Callbacks
@@ -56,7 +63,7 @@ defmodule Broadway.Topology do
 
     emit_init_event(opts, supervisor_pid)
 
-    :persistent_term.put(config.name, %{
+    :persistent_term.put({Broadway, config.name}, %Config{
       context: config.context,
       topology: build_topology_details(config),
       producer_names: process_names(config.name, "Producer", config.producer_config),
@@ -90,7 +97,7 @@ defmodule Broadway.Topology do
     Process.exit(supervisor_pid, reason_to_signal(reason))
 
     receive do
-      {:DOWN, ^ref, _, _, _} -> :persistent_term.erase(name)
+      {:DOWN, ^ref, _, _, _} -> :persistent_term.erase({Broadway, name})
     end
 
     :ok

--- a/lib/broadway/topology.ex
+++ b/lib/broadway/topology.ex
@@ -11,11 +11,7 @@ defmodule Broadway.Topology do
     RateLimiter
   }
 
-  defmodule Config do
-    @moduledoc false
-
-    defstruct [:context, :topology, :producer_names, :batchers_names, :rate_limiter_name]
-  end
+  defstruct [:context, :topology, :producer_names, :batchers_names, :rate_limiter_name]
 
   def start_link(module, opts) do
     GenServer.start_link(__MODULE__, {module, opts}, opts)
@@ -63,7 +59,7 @@ defmodule Broadway.Topology do
 
     emit_init_event(opts, supervisor_pid)
 
-    :persistent_term.put({Broadway, config.name}, %Config{
+    :persistent_term.put({Broadway, config.name}, %__MODULE__{
       context: config.context,
       topology: build_topology_details(config),
       producer_names: process_names(config.name, "Producer", config.producer_config),

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -1208,9 +1208,6 @@ defmodule BroadwayTest do
 
       assert processor_1 != processor_2
       assert batch_processor_1 != batch_processor_2
-
-      # NOTE: we need to stop this one because is not stopping alone and causing intermittence.
-      GenServer.stop(broadway)
     end
   end
 

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -2444,7 +2444,7 @@ defmodule BroadwayTest do
     end
   end
 
-  describe "all/0" do
+  describe "all_running/0" do
     test "return running pipeline names" do
       broadway = new_unique_name()
 
@@ -2456,7 +2456,7 @@ defmodule BroadwayTest do
         batchers: [default: [concurrency: 12], b1: [concurrency: 13]]
       )
 
-      assert Broadway.all() == [broadway]
+      assert Broadway.all_running() == [broadway]
 
       broadway2 = new_unique_name()
 
@@ -2468,15 +2468,15 @@ defmodule BroadwayTest do
         batchers: [default: [concurrency: 12], b1: [concurrency: 13]]
       )
 
-      assert Enum.sort(Broadway.all()) == [broadway, broadway2]
+      assert Enum.sort(Broadway.all_running()) == [broadway, broadway2]
 
       GenServer.stop(broadway2)
 
-      assert Broadway.all() == [broadway]
+      assert Broadway.all_running() == [broadway]
 
       GenServer.stop(broadway)
 
-      assert Broadway.all() == []
+      assert Broadway.all_running() == []
     end
   end
 


### PR DESCRIPTION
Also change the value to use a struct. The reason for these changes is
to make easier to detect a Broadway pipeline config from
`:persistent_term`.