### PR TITLE
Add `index` and `topology_name` to telemetry event metadata

### DIFF
--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -563,7 +563,7 @@ defmodule Broadway do
       before the optional `c:prepare_messages/2`
 
       * Measurement: `%{time: System.monotonic_time}`
-      * Metadata: `%{name: atom, messages: [Broadway.Message.t]}`
+      * Metadata: `%{broadway_name: atom, name: atom, messages: [Broadway.Message.t]}`
 
     * `[:broadway, :processor, :stop]` -  Dispatched by a Broadway processor
       after `c:prepare_messages/2` and after all `c:handle_message/3` callback
@@ -575,6 +575,7 @@ defmodule Broadway do
 
         ```
         %{
+          broadway_name: atom,
           name: atom,
           successful_messages_to_ack: [Broadway.Message.t],
           successful_messages_to_forward: [Broadway.Message.t],
@@ -592,6 +593,7 @@ defmodule Broadway do
         ```
         %{
           processor_key: atom,
+          broadway_name: atom,
           name: atom,
           message: Broadway.Message.t
         }
@@ -607,6 +609,7 @@ defmodule Broadway do
         ```
         %{
           processor_key: atom,
+          broadway_name: atom,
           name: atom,
           message: Broadway.Message.t,
           updated_message: Broadway.Message.t
@@ -623,6 +626,7 @@ defmodule Broadway do
         ```
         %{
           processor_key: atom,
+          broadway_name: atom,
           name: atom,
           message: Broadway.Message.t,
           kind: kind,

--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -567,9 +567,9 @@ defmodule Broadway do
 
         ```
         %{
-          broadway_name: atom,
+          topology_name: atom,
           name: atom,
-          partition: non_neg_integer,
+          index: non_neg_integer,
           messages: [Broadway.Message.t]
         }
         ```
@@ -584,9 +584,9 @@ defmodule Broadway do
 
         ```
         %{
-          broadway_name: atom,
+          topology_name: atom,
           name: atom,
-          partition: non_neg_integer,
+          index: non_neg_integer,
           successful_messages_to_ack: [Broadway.Message.t],
           successful_messages_to_forward: [Broadway.Message.t],
           failed_messages: [Broadway.Message.t]
@@ -603,9 +603,9 @@ defmodule Broadway do
         ```
         %{
           processor_key: atom,
-          broadway_name: atom,
+          topology_name: atom,
           name: atom,
-          partition: non_neg_integer,
+          index: non_neg_integer,
           message: Broadway.Message.t
         }
         ```
@@ -620,9 +620,9 @@ defmodule Broadway do
         ```
         %{
           processor_key: atom,
-          broadway_name: atom,
+          topology_name: atom,
           name: atom,
-          partition: non_neg_integer,
+          index: non_neg_integer,
           message: Broadway.Message.t,
           updated_message: Broadway.Message.t
         }
@@ -638,9 +638,9 @@ defmodule Broadway do
         ```
         %{
           processor_key: atom,
-          broadway_name: atom,
+          topology_name: atom,
           name: atom,
-          partition: non_neg_integer,
+          index: non_neg_integer,
           message: Broadway.Message.t,
           kind: kind,
           reason: reason,
@@ -656,9 +656,9 @@ defmodule Broadway do
 
         ```
         %{
-          broadway_name: atom,
+          topology_name: atom,
           name: atom,
-          partition: non_neg_integer,
+          index: non_neg_integer,
           messages: [Broadway.Message.t],
           batch_info: Broadway.BatchInfo.t
         }
@@ -673,9 +673,9 @@ defmodule Broadway do
 
         ```
         %{
-          broadway_name: atom,
+          topology_name: atom,
           name: atom,
-          partition: non_neg_integer,
+          index: non_neg_integer,
           successful_messages: [Broadway.Message.t],
           failed_messages: [Broadway.Message.t],
           batch_info: Broadway.BatchInfo.t
@@ -690,7 +690,7 @@ defmodule Broadway do
 
         ```
         %{
-          broadway_name: atom,
+          topology_name: atom,
           name: atom,
           messages: [{Broadway.Message.t}]
         }
@@ -700,7 +700,7 @@ defmodule Broadway do
       handling events
 
       * Measurement: `%{time: System.monotonic_time, duration: native_time}`
-      * Metadata: `%{broadway_name: atom, name: atom}`
+      * Metadata: `%{topology_name: atom, name: atom}`
   """
 
   alias Broadway.{BatchInfo, Message, Topology}

--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -658,6 +658,7 @@ defmodule Broadway do
         %{
           broadway_name: atom,
           name: atom,
+          partition: non_neg_integer,
           messages: [Broadway.Message.t],
           batch_info: Broadway.BatchInfo.t
         }
@@ -674,6 +675,7 @@ defmodule Broadway do
         %{
           broadway_name: atom,
           name: atom,
+          partition: non_neg_integer,
           successful_messages: [Broadway.Message.t],
           failed_messages: [Broadway.Message.t],
           batch_info: Broadway.BatchInfo.t
@@ -690,7 +692,6 @@ defmodule Broadway do
         %{
           broadway_name: atom,
           name: atom,
-          partition: non_neg_integer,
           messages: [{Broadway.Message.t}]
         }
         ```
@@ -699,7 +700,7 @@ defmodule Broadway do
       handling events
 
       * Measurement: `%{time: System.monotonic_time, duration: native_time}`
-      * Metadata: `%{broadway_name: atom, name: atom, partition: non_neg_integer}`
+      * Metadata: `%{broadway_name: atom, name: atom}`
   """
 
   alias Broadway.{BatchInfo, Message, Topology}

--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -643,6 +643,7 @@ defmodule Broadway do
 
         ```
         %{
+          broadway_name: atom,
           name: atom,
           messages: [Broadway.Message.t],
           batch_info: Broadway.BatchInfo.t
@@ -658,6 +659,7 @@ defmodule Broadway do
 
         ```
         %{
+          broadway_name: atom,
           name: atom,
           successful_messages: [Broadway.Message.t],
           failed_messages: [Broadway.Message.t],

--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -563,7 +563,16 @@ defmodule Broadway do
       before the optional `c:prepare_messages/2`
 
       * Measurement: `%{time: System.monotonic_time}`
-      * Metadata: `%{broadway_name: atom, name: atom, messages: [Broadway.Message.t]}`
+      * Metadata:
+
+        ```
+        %{
+          broadway_name: atom,
+          name: atom,
+          partition: non_neg_integer,
+          messages: [Broadway.Message.t]
+        }
+        ```
 
     * `[:broadway, :processor, :stop]` -  Dispatched by a Broadway processor
       after `c:prepare_messages/2` and after all `c:handle_message/3` callback
@@ -577,6 +586,7 @@ defmodule Broadway do
         %{
           broadway_name: atom,
           name: atom,
+          partition: non_neg_integer,
           successful_messages_to_ack: [Broadway.Message.t],
           successful_messages_to_forward: [Broadway.Message.t],
           failed_messages: [Broadway.Message.t]
@@ -595,6 +605,7 @@ defmodule Broadway do
           processor_key: atom,
           broadway_name: atom,
           name: atom,
+          partition: non_neg_integer,
           message: Broadway.Message.t
         }
         ```
@@ -611,6 +622,7 @@ defmodule Broadway do
           processor_key: atom,
           broadway_name: atom,
           name: atom,
+          partition: non_neg_integer,
           message: Broadway.Message.t,
           updated_message: Broadway.Message.t
         }
@@ -628,6 +640,7 @@ defmodule Broadway do
           processor_key: atom,
           broadway_name: atom,
           name: atom,
+          partition: non_neg_integer,
           message: Broadway.Message.t,
           kind: kind,
           reason: reason,
@@ -671,13 +684,22 @@ defmodule Broadway do
       handling events
 
       * Measurement: `%{time: System.monotonic_time}`
-      * Metadata: `%{broadway_name: atom, name: atom, messages: [{Broadway.Message.t}]}`
+      * Metadata:
+
+        ```
+        %{
+          broadway_name: atom,
+          name: atom,
+          partition: non_neg_integer,
+          messages: [{Broadway.Message.t}]
+        }
+        ```
 
     * `[:broadway, :batcher, :stop]` - Dispatched by a Broadway batcher after
       handling events
 
       * Measurement: `%{time: System.monotonic_time, duration: native_time}`
-      * Metadata: `%{broadway_name: atom, name: atom}`
+      * Metadata: `%{broadway_name: atom, name: atom, partition: non_neg_integer}`
   """
 
   alias Broadway.{BatchInfo, Message, Topology}

--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -671,13 +671,13 @@ defmodule Broadway do
       handling events
 
       * Measurement: `%{time: System.monotonic_time}`
-      * Metadata: `%{name: atom, messages: [{Broadway.Message.t}]}`
+      * Metadata: `%{broadway_name: atom, name: atom, messages: [{Broadway.Message.t}]}`
 
     * `[:broadway, :batcher, :stop]` - Dispatched by a Broadway batcher after
       handling events
 
       * Measurement: `%{time: System.monotonic_time, duration: native_time}`
-      * Metadata: `%{name: atom}`
+      * Metadata: `%{broadway_name: atom, name: atom}`
   """
 
   alias Broadway.{BatchInfo, Message, Topology}

--- a/lib/broadway/topology.ex
+++ b/lib/broadway/topology.ex
@@ -340,6 +340,7 @@ defmodule Broadway.Topology do
 
     args =
       [
+        broadway_name: config.name,
         name: name,
         resubscribe: :never,
         terminator: terminator,

--- a/lib/broadway/topology.ex
+++ b/lib/broadway/topology.ex
@@ -272,6 +272,7 @@ defmodule Broadway.Topology do
       end
 
     args = [
+      broadway_name: broadway_name,
       type: type,
       resubscribe: resubscribe_interval,
       terminator: terminator,
@@ -287,7 +288,7 @@ defmodule Broadway.Topology do
     specs =
       for {name, index} <- Enum.with_index(names) do
         start_options = start_options(name, processor_config)
-        args = [broadway_name: broadway_name, name: name, partition: index] ++ args
+        args = [name: name, partition: index] ++ args
 
         %{
           start: {ProcessorStage, :start_link, [args, start_options]},
@@ -376,6 +377,7 @@ defmodule Broadway.Topology do
     names = process_names(broadway_name, "BatchProcessor_#{key}", batcher_config)
 
     args = [
+      broadway_name: broadway_name,
       resubscribe: :never,
       terminator: terminator,
       module: module,

--- a/lib/broadway/topology.ex
+++ b/lib/broadway/topology.ex
@@ -237,7 +237,7 @@ defmodule Broadway.Topology do
 
   defp build_processors_specs(config, producers) do
     %{
-      name: broadway_name,
+      name: topology_name,
       module: module,
       processors_config: processors_config,
       context: context,
@@ -253,7 +253,7 @@ defmodule Broadway.Topology do
       raise "Only one set of processors is allowed for now"
     end
 
-    names = process_names(broadway_name, "Processor_#{key}", processor_config)
+    names = process_names(topology_name, "Processor_#{key}", processor_config)
 
     # The partition of the processor depends on the next processor or the batcher,
     # so we handle it here.
@@ -272,7 +272,7 @@ defmodule Broadway.Topology do
       end
 
     args = [
-      broadway_name: broadway_name,
+      topology_name: topology_name,
       type: type,
       resubscribe: resubscribe_interval,
       terminator: terminator,
@@ -341,7 +341,7 @@ defmodule Broadway.Topology do
 
     args =
       [
-        broadway_name: config.name,
+        topology_name: config.name,
         name: name,
         resubscribe: :never,
         terminator: terminator,
@@ -377,7 +377,7 @@ defmodule Broadway.Topology do
     names = process_names(broadway_name, "BatchProcessor_#{key}", batcher_config)
 
     args = [
-      broadway_name: broadway_name,
+      topology_name: broadway_name,
       resubscribe: :never,
       terminator: terminator,
       module: module,

--- a/lib/broadway/topology.ex
+++ b/lib/broadway/topology.ex
@@ -287,7 +287,7 @@ defmodule Broadway.Topology do
     specs =
       for {name, index} <- Enum.with_index(names) do
         start_options = start_options(name, processor_config)
-        args = [name: name, partition: index] ++ args
+        args = [broadway_name: broadway_name, name: name, partition: index] ++ args
 
         %{
           start: {ProcessorStage, :start_link, [args, start_options]},

--- a/lib/broadway/topology/batch_processor_stage.ex
+++ b/lib/broadway/topology/batch_processor_stage.ex
@@ -21,7 +21,7 @@ defmodule Broadway.Topology.BatchProcessorStage do
     Process.flag(:trap_exit, true)
 
     state = %{
-      broadway_name: args[:broadway_name],
+      topology_name: args[:topology_name],
       name: args[:name],
       partition: args[:partition],
       module: args[:module],
@@ -84,9 +84,9 @@ defmodule Broadway.Topology.BatchProcessorStage do
 
   defp emit_start_event(state, start_time, messages, batch_info) do
     metadata = %{
-      broadway_name: state.broadway_name,
+      topology_name: state.topology_name,
       name: state.name,
-      partition: state.partition,
+      index: state.partition,
       messages: messages,
       batch_info: batch_info
     }
@@ -97,9 +97,9 @@ defmodule Broadway.Topology.BatchProcessorStage do
 
   defp emit_stop_event(state, start_time, successful_messages, failed_messages, batch_info) do
     metadata = %{
-      broadway_name: state.broadway_name,
+      topology_name: state.topology_name,
       name: state.name,
-      partition: state.partition,
+      index: state.partition,
       successful_messages: successful_messages,
       failed_messages: failed_messages,
       batch_info: batch_info

--- a/lib/broadway/topology/batcher_stage.ex
+++ b/lib/broadway/topology/batcher_stage.ex
@@ -36,6 +36,7 @@ defmodule Broadway.Topology.BatcherStage do
       end
 
     state = %{
+      broadway_name: args[:broadway_name],
       name: args[:name],
       batcher: args[:batcher],
       batch_size: args[:batch_size],
@@ -49,22 +50,22 @@ defmodule Broadway.Topology.BatcherStage do
   @impl true
   def handle_events(events, _from, state) do
     start_time = System.monotonic_time()
-    emit_start_event(state.name, start_time, events)
+    emit_start_event(state.broadway_name, state.name, start_time, events)
     batches = handle_events_per_batch_key(events, [], state)
-    emit_stop_event(state.name, start_time)
+    emit_stop_event(state.broadway_name, state.name, start_time)
     {:noreply, batches, state}
   end
 
-  defp emit_start_event(name, start_time, events) do
-    metadata = %{name: name, messages: events}
+  defp emit_start_event(broadway_name, name, start_time, events) do
+    metadata = %{broadway_name: broadway_name, name: name, messages: events}
     measurements = %{time: start_time}
     :telemetry.execute([:broadway, :batcher, :start], measurements, metadata)
   end
 
-  defp emit_stop_event(name, start_time) do
+  defp emit_stop_event(broadway_name, name, start_time) do
     stop_time = System.monotonic_time()
     measurements = %{time: stop_time, duration: stop_time - start_time}
-    metadata = %{name: name}
+    metadata = %{broadway_name: broadway_name, name: name}
     :telemetry.execute([:broadway, :batcher, :stop], measurements, metadata)
   end
 

--- a/lib/broadway/topology/batcher_stage.ex
+++ b/lib/broadway/topology/batcher_stage.ex
@@ -36,7 +36,7 @@ defmodule Broadway.Topology.BatcherStage do
       end
 
     state = %{
-      broadway_name: args[:broadway_name],
+      topology_name: args[:topology_name],
       name: args[:name],
       batcher: args[:batcher],
       batch_size: args[:batch_size],
@@ -50,22 +50,22 @@ defmodule Broadway.Topology.BatcherStage do
   @impl true
   def handle_events(events, _from, state) do
     start_time = System.monotonic_time()
-    emit_start_event(state.broadway_name, state.name, start_time, events)
+    emit_start_event(state.topology_name, state.name, start_time, events)
     batches = handle_events_per_batch_key(events, [], state)
-    emit_stop_event(state.broadway_name, state.name, start_time)
+    emit_stop_event(state.topology_name, state.name, start_time)
     {:noreply, batches, state}
   end
 
-  defp emit_start_event(broadway_name, name, start_time, events) do
-    metadata = %{broadway_name: broadway_name, name: name, messages: events}
+  defp emit_start_event(topology_name, name, start_time, events) do
+    metadata = %{topology_name: topology_name, name: name, messages: events}
     measurements = %{time: start_time}
     :telemetry.execute([:broadway, :batcher, :start], measurements, metadata)
   end
 
-  defp emit_stop_event(broadway_name, name, start_time) do
+  defp emit_stop_event(topology_name, name, start_time) do
     stop_time = System.monotonic_time()
     measurements = %{time: stop_time, duration: stop_time - start_time}
-    metadata = %{broadway_name: broadway_name, name: name}
+    metadata = %{topology_name: topology_name, name: name}
     :telemetry.execute([:broadway, :batcher, :stop], measurements, metadata)
   end
 

--- a/lib/broadway/topology/processor_stage.ex
+++ b/lib/broadway/topology/processor_stage.ex
@@ -22,7 +22,7 @@ defmodule Broadway.Topology.ProcessorStage do
     type = args[:type]
 
     state = %{
-      broadway_name: args[:broadway_name],
+      topology_name: args[:topology_name],
       name: args[:name],
       partition: args[:partition],
       type: type,
@@ -93,9 +93,9 @@ defmodule Broadway.Topology.ProcessorStage do
 
   defp emit_start_event(state, start_time, messages) do
     metadata = %{
-      broadway_name: state.broadway_name,
+      topology_name: state.topology_name,
       name: state.name,
-      partition: state.partition,
+      index: state.partition,
       messages: messages
     }
 
@@ -112,9 +112,9 @@ defmodule Broadway.Topology.ProcessorStage do
          failed_messages
        ) do
     metadata = %{
-      broadway_name: state.broadway_name,
+      topology_name: state.topology_name,
       name: state.name,
-      partition: state.partition,
+      index: state.partition,
       successful_messages_to_ack: successful_messages_to_ack,
       successful_messages_to_forward: successful_messages_to_forward,
       failed_messages: failed_messages
@@ -205,8 +205,8 @@ defmodule Broadway.Topology.ProcessorStage do
   defp emit_message_start_event(start_time, state, message) do
     metadata = %{
       processor_key: state.processor_key,
-      broadway_name: state.broadway_name,
-      partition: state.partition,
+      topology_name: state.topology_name,
+      index: state.partition,
       name: state.name,
       message: message
     }
@@ -220,8 +220,8 @@ defmodule Broadway.Topology.ProcessorStage do
 
     metadata = %{
       processor_key: state.processor_key,
-      broadway_name: state.broadway_name,
-      partition: state.partition,
+      topology_name: state.topology_name,
+      index: state.partition,
       name: state.name,
       message: message
     }
@@ -242,9 +242,9 @@ defmodule Broadway.Topology.ProcessorStage do
 
     metadata = %{
       processor_key: state.processor_key,
-      broadway_name: state.broadway_name,
+      topology_name: state.topology_name,
       name: state.name,
-      partition: state.partition,
+      index: state.partition,
       message: message,
       kind: kind,
       reason: reason,

--- a/lib/broadway/topology/processor_stage.ex
+++ b/lib/broadway/topology/processor_stage.ex
@@ -92,8 +92,15 @@ defmodule Broadway.Topology.ProcessorStage do
   end
 
   defp emit_start_event(state, start_time, messages) do
-    metadata = %{broadway_name: state.broadway_name, name: state.name, messages: messages}
+    metadata = %{
+      broadway_name: state.broadway_name,
+      name: state.name,
+      partition: state.partition,
+      messages: messages
+    }
+
     measurements = %{time: start_time}
+
     :telemetry.execute([:broadway, :processor, :start], measurements, metadata)
   end
 

--- a/lib/broadway/topology/processor_stage.ex
+++ b/lib/broadway/topology/processor_stage.ex
@@ -107,6 +107,7 @@ defmodule Broadway.Topology.ProcessorStage do
     metadata = %{
       broadway_name: state.broadway_name,
       name: state.name,
+      partition: state.partition,
       successful_messages_to_ack: successful_messages_to_ack,
       successful_messages_to_forward: successful_messages_to_forward,
       failed_messages: failed_messages

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -869,6 +869,8 @@ defmodule BroadwayTest do
       assert_receive {:telemetry_event, [:broadway, :processor, :message, :exception], %{}, %{}}
       assert_receive {:telemetry_event, [:broadway, :processor, :stop], %{}, %{}}
       assert_receive {:ack, ^ref, [], [%{status: {:error, _, _}}]}
+
+      :telemetry.detach("#{test}")
     end
   end
 

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -801,7 +801,19 @@ defmodule BroadwayTest do
             [:broadway, :processor, :message, :exception]
           ],
           fn name, measurements, metadata, _ ->
+            assert metadata.name
             assert metadata.broadway_name == broadway
+
+            case name do
+              [:broadway, stage, _] when stage in [:processor, :consumer] ->
+                assert is_integer(metadata.partition)
+
+              [:broadway, :processor, :message, _] ->
+                assert is_integer(metadata.partition)
+
+              _ ->
+                :ok
+            end
 
             send(self, {:telemetry_event, name, measurements, metadata})
           end,

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -815,7 +815,9 @@ defmodule BroadwayTest do
       assert_receive {:ack, ^ref, [], [%{status: {:failed, "Failed message"}}]}
       assert_receive {:ack, ^ref, [], [%{status: {:failed, "Failed batcher"}}]}
 
-      assert_receive {:telemetry_event, [:broadway, :processor, :start], %{}, %{}}
+      assert_receive {:telemetry_event, [:broadway, :processor, :start], %{},
+                      %{broadway_name: ^broadway}}
+
       assert_receive {:telemetry_event, [:broadway, :processor, :message, :start], %{}, %{}}
       assert_receive {:telemetry_event, [:broadway, :processor, :message, :stop], %{}, %{}}
       assert_receive {:telemetry_event, [:broadway, :processor, :stop], %{}, metadata}

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -802,14 +802,14 @@ defmodule BroadwayTest do
           ],
           fn name, measurements, metadata, _ ->
             assert metadata.name
-            assert metadata.broadway_name == broadway
+            assert metadata.topology_name == broadway
 
             case name do
               [:broadway, stage, _] when stage in [:processor, :consumer] ->
-                assert is_integer(metadata.partition)
+                assert is_integer(metadata.index)
 
               [:broadway, :processor, :message, _] ->
-                assert is_integer(metadata.partition)
+                assert is_integer(metadata.index)
 
               _ ->
                 :ok

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -801,6 +801,8 @@ defmodule BroadwayTest do
             [:broadway, :processor, :message, :exception]
           ],
           fn name, measurements, metadata, _ ->
+            assert metadata.broadway_name == broadway
+
             send(self, {:telemetry_event, name, measurements, metadata})
           end,
           nil
@@ -815,8 +817,7 @@ defmodule BroadwayTest do
       assert_receive {:ack, ^ref, [], [%{status: {:failed, "Failed message"}}]}
       assert_receive {:ack, ^ref, [], [%{status: {:failed, "Failed batcher"}}]}
 
-      assert_receive {:telemetry_event, [:broadway, :processor, :start], %{},
-                      %{broadway_name: ^broadway}}
+      assert_receive {:telemetry_event, [:broadway, :processor, :start], %{}, %{}}
 
       assert_receive {:telemetry_event, [:broadway, :processor, :message, :start], %{}, %{}}
       assert_receive {:telemetry_event, [:broadway, :processor, :message, :stop], %{}, %{}}


### PR DESCRIPTION
This PR adds these two fields in order to better inspect which stage and Broadway is emitting the event.

Discussion from: https://github.com/dashbitco/broadway_dashboard/pull/2#issuecomment-850603896