### PR TITLE
Use GenServer.whereis() in remaining places to support via tuples

### DIFF
--- a/lib/broadway/topology/terminator.ex
+++ b/lib/broadway/topology/terminator.ex
@@ -36,15 +36,15 @@ defmodule Broadway.Topology.Terminator do
 
   @impl true
   def terminate(_, state) do
-    for name <- state.first, pid = Process.whereis(name) do
+    for name <- state.first, pid = GenServer.whereis(name) do
       send(pid, :will_terminate)
     end
 
-    for name <- state.producers, pid = Process.whereis(name) do
+    for name <- state.producers, pid = GenServer.whereis(name) do
       Broadway.Topology.ProducerStage.drain(pid)
     end
 
-    for name <- state.last, pid = Process.whereis(name) do
+    for name <- state.last, pid = GenServer.whereis(name) do
       ref = Process.monitor(pid)
 
       receive do

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -2530,19 +2530,16 @@ defmodule BroadwayTest do
     end
 
     test "Broadway.topology/1", %{name: name} do
-      assert Broadway.topology(name) == [
-               {:producers, [%{concurrency: 1, name: via_tuple({:broadway, "Producer"})}]},
-               {:processors,
-                [%{concurrency: 16, name: via_tuple({:broadway, "Processor_default"})}]},
-               {:batchers,
-                [
-                  %{
-                    batcher_name: via_tuple({:broadway, "Batcher_default"}),
-                    concurrency: 1,
-                    name: via_tuple({:broadway, "BatchProcessor_default"})
-                  }
-                ]}
-             ]
+      producer_name = via_tuple({:broadway, "Producer"})
+      processor_name = via_tuple({:broadway, "Processor_default"})
+      batcher_name = via_tuple({:broadway, "Batcher_default"})
+      batch_processor_name = via_tuple({:broadway, "BatchProcessor_default"})
+
+      assert [
+               {:producers, [%{name: ^producer_name}]},
+               {:processors, [%{name: ^processor_name}]},
+               {:batchers, [%{batcher_name: ^batcher_name, name: ^batch_processor_name}]}
+             ] = Broadway.topology(name)
     end
 
     test "Broadway.test_message/2", %{name: name} do


### PR DESCRIPTION
Playing with this locally, realized I missed a few call sites. These are the last ones outside of test where we are using `Process.whereis` as opposed to `GenServer.whereis`