### PR TITLE
Add "keys" to telemetry events and topology/1

### DIFF
--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -569,6 +569,7 @@ defmodule Broadway do
         %{
           topology_name: atom,
           name: atom,
+          processor_key: atom,
           index: non_neg_integer,
           messages: [Broadway.Message.t]
         }
@@ -586,6 +587,7 @@ defmodule Broadway do
         %{
           topology_name: atom,
           name: atom,
+          processor_key: atom,
           index: non_neg_integer,
           successful_messages_to_ack: [Broadway.Message.t],
           successful_messages_to_forward: [Broadway.Message.t],
@@ -692,6 +694,7 @@ defmodule Broadway do
         %{
           topology_name: atom,
           name: atom,
+          batcher_key: atom,
           messages: [{Broadway.Message.t}]
         }
         ```
@@ -700,7 +703,7 @@ defmodule Broadway do
       handling events
 
       * Measurement: `%{time: System.monotonic_time, duration: native_time}`
-      * Metadata: `%{topology_name: atom, name: atom}`
+      * Metadata: `%{topology_name: atom, name: atom, batcher_key: atom}`
   """
 
   alias Broadway.{BatchInfo, Message, Topology}
@@ -967,16 +970,18 @@ defmodule Broadway do
       iex> Broadway.topology(MyBroadway)
       [
         producers: [%{name: MyBroadway.Broadway.Producer, concurrency: 1}],
-        processors: [%{name: MyBroadway.Broadway.Processor_default, concurrency: 10}],
+        processors: [%{name: MyBroadway.Broadway.Processor_default, concurrency: 10, processor_key: :default}],
         batchers: [
           %{
             batcher_name: MyBroadway.Broadway.Batcher_default,
             name: MyBroadway.Broadway.BatchProcessor_default,
+            batcher_key: :default,
             concurrency: 5
           },
           %{
             batcher_name: MyBroadway.Broadway.Batcher_s3,
             name: MyBroadway.Broadway.BatchProcessor_s3,
+            batcher_key: :s3,
             concurrency: 3
           }
         ]
@@ -989,7 +994,9 @@ defmodule Broadway do
              %{
                required(:name) => atom(),
                optional(:concurrency) => pos_integer(),
-               optional(:batcher_name) => atom()
+               optional(:batcher_name) => atom(),
+               optional(:batcher_key) => atom(),
+               optional(:processor_key) => atom()
              }
            ]}
         ]

--- a/lib/broadway/topology.ex
+++ b/lib/broadway/topology.ex
@@ -448,6 +448,7 @@ defmodule Broadway.Topology do
         Enum.map(config.processors_config, fn {name, processor_config} ->
           %{
             name: process_name(config, "Processor", name),
+            processor_key: name,
             concurrency: processor_config[:concurrency]
           }
         end),
@@ -455,6 +456,7 @@ defmodule Broadway.Topology do
         Enum.map(config.batchers_config, fn {name, batcher_config} ->
           %{
             batcher_name: process_name(config, "Batcher", name),
+            batcher_key: name,
             name: process_name(config, "BatchProcessor", name),
             concurrency: batcher_config[:concurrency]
           }

--- a/lib/broadway/topology/processor_stage.ex
+++ b/lib/broadway/topology/processor_stage.ex
@@ -96,6 +96,7 @@ defmodule Broadway.Topology.ProcessorStage do
       topology_name: state.topology_name,
       name: state.name,
       index: state.partition,
+      processor_key: state.processor_key,
       messages: messages
     }
 
@@ -117,6 +118,7 @@ defmodule Broadway.Topology.ProcessorStage do
       index: state.partition,
       successful_messages_to_ack: successful_messages_to_ack,
       successful_messages_to_forward: successful_messages_to_forward,
+      processor_key: state.processor_key,
       failed_messages: failed_messages
     }
 


### PR DESCRIPTION
This commit adds `batcher_key` and `processor_key` to events that don't
have it yet. This attribute is the same from the name of the processors
or the batchers that goes in the Broadway configuration.

The same keys are present now in the topology description. This can help
users to match telemetry events with the topology.