### PR TITLE
Changed telemetry docs so they are consistent.

### DIFF
--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -702,7 +702,15 @@ defmodule Broadway do
       handling events
 
       * Measurement: `%{time: System.monotonic_time, duration: native_time}`
-      * Metadata: `%{topology_name: atom, name: atom, batcher_key: atom}`
+      * Metadata:
+
+      ```
+        %{
+          topology_name: atom,
+          name: atom,
+          batcher_key: atom
+        }
+      ```
   """
 
   alias Broadway.{BatchInfo, Message, Topology}


### PR DESCRIPTION
This metadata field was formatted differently and after docs were produced it sticks like sore eye. I think it would be beneficial to just keep it consistent.