### PR TITLE
Add trigger field to BatchInfo

### DIFF
--- a/lib/broadway/batch_info.ex
+++ b/lib/broadway/batch_info.ex
@@ -12,7 +12,7 @@ defmodule Broadway.BatchInfo do
           batch_key: term,
           partition: non_neg_integer | nil,
           size: pos_integer,
-          is_full: boolean
+          trigger: atom
         }
 
   defstruct [
@@ -20,6 +20,6 @@ defmodule Broadway.BatchInfo do
     :batch_key,
     :partition,
     :size,
-    :is_full
+    :trigger
   ]
 end

--- a/lib/broadway/batch_info.ex
+++ b/lib/broadway/batch_info.ex
@@ -11,13 +11,15 @@ defmodule Broadway.BatchInfo do
           batcher: atom,
           batch_key: term,
           partition: non_neg_integer | nil,
-          size: pos_integer
+          size: pos_integer,
+          is_full: boolean
         }
 
   defstruct [
     :batcher,
     :batch_key,
     :partition,
-    :size
+    :size,
+    :is_full
   ]
 end

--- a/lib/broadway/topology/batcher_stage.ex
+++ b/lib/broadway/topology/batcher_stage.ex
@@ -227,7 +227,8 @@ defmodule Broadway.Topology.BatcherStage do
       batcher: batcher,
       batch_key: batch_key,
       partition: partition,
-      size: batch_size - pending
+      size: batch_size - pending,
+      is_full: pending == 0
     }
 
     {Enum.reverse(reversed_events), batch_info}

--- a/lib/broadway/topology/batcher_stage.ex
+++ b/lib/broadway/topology/batcher_stage.ex
@@ -222,13 +222,20 @@ defmodule Broadway.Topology.BatcherStage do
 
   defp wrap_for_delivery(batch_key, partition, reversed_events, pending, state) do
     %{batcher: batcher, batch_size: batch_size} = state
+    [event | _] = reversed_events
+
+    trigger =
+      case event.batch_mode do
+        :bulk -> if(pending == 0, do: :size, else: :timeout)
+        :flush -> :flush
+      end
 
     batch_info = %BatchInfo{
       batcher: batcher,
       batch_key: batch_key,
       partition: partition,
       size: batch_size - pending,
-      is_full: pending == 0
+      trigger: trigger
     }
 
     {Enum.reverse(reversed_events), batch_info}

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -1005,27 +1005,27 @@ defmodule BroadwayTest do
       Broadway.test_batch(broadway, Enum.to_list(1..40))
 
       assert_receive {:batch_handled, :odd, messages,
-                      %BatchInfo{batcher: :odd, size: 10, is_full: true}}
+                      %BatchInfo{batcher: :odd, size: 10, trigger: :size}}
                      when length(messages) == 10
 
       assert_receive {:batch_handled, :odd, messages,
-                      %BatchInfo{batcher: :odd, size: 10, is_full: true}}
+                      %BatchInfo{batcher: :odd, size: 10, trigger: :size}}
                      when length(messages) == 10
 
       assert_receive {:batch_handled, :even, messages,
-                      %BatchInfo{batcher: :even, size: 5, is_full: true}}
+                      %BatchInfo{batcher: :even, size: 5, trigger: :size}}
                      when length(messages) == 5
 
       assert_receive {:batch_handled, :even, messages,
-                      %BatchInfo{batcher: :even, size: 5, is_full: true}}
+                      %BatchInfo{batcher: :even, size: 5, trigger: :size}}
                      when length(messages) == 5
 
       assert_receive {:batch_handled, :even, messages,
-                      %BatchInfo{batcher: :even, size: 5, is_full: true}}
+                      %BatchInfo{batcher: :even, size: 5, trigger: :size}}
                      when length(messages) == 5
 
       assert_receive {:batch_handled, :even, messages,
-                      %BatchInfo{batcher: :even, size: 5, is_full: true}}
+                      %BatchInfo{batcher: :even, size: 5, trigger: :size}}
                      when length(messages) == 5
 
       refute_received {:batch_handled, _, _}
@@ -1035,10 +1035,10 @@ defmodule BroadwayTest do
          %{broadway: broadway} do
       Broadway.test_batch(broadway, [1, 2, 3, 4, 5], batch_mode: :flush)
 
-      assert_receive {:batch_handled, :odd, messages, %BatchInfo{is_full: false}}
+      assert_receive {:batch_handled, :odd, messages, %BatchInfo{trigger: :flush}}
                      when length(messages) == 3
 
-      assert_receive {:batch_handled, :even, messages, %BatchInfo{is_full: false}}
+      assert_receive {:batch_handled, :even, messages, %BatchInfo{trigger: :flush}}
                      when length(messages) == 2
 
       refute_received {:batch_handled, _, _, _}
@@ -1087,10 +1087,10 @@ defmodule BroadwayTest do
                       []}
 
       assert_receive {:batch_handled, :default,
-                      %BatchInfo{batch_key: :odd, size: 2, is_full: true}}
+                      %BatchInfo{batch_key: :odd, size: 2, trigger: :size}}
 
       assert_receive {:batch_handled, :default,
-                      %BatchInfo{batch_key: :even, size: 2, is_full: true}}
+                      %BatchInfo{batch_key: :even, size: 2, trigger: :size}}
     end
 
     test "generate batches with the remaining messages after :batch_timeout is reached",

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -1004,22 +1004,28 @@ defmodule BroadwayTest do
     test "generate batches based on :batch_size", %{broadway: broadway} do
       Broadway.test_batch(broadway, Enum.to_list(1..40))
 
-      assert_receive {:batch_handled, :odd, messages, %BatchInfo{batcher: :odd, size: 10}}
+      assert_receive {:batch_handled, :odd, messages,
+                      %BatchInfo{batcher: :odd, size: 10, is_full: true}}
                      when length(messages) == 10
 
-      assert_receive {:batch_handled, :odd, messages, %BatchInfo{batcher: :odd, size: 10}}
+      assert_receive {:batch_handled, :odd, messages,
+                      %BatchInfo{batcher: :odd, size: 10, is_full: true}}
                      when length(messages) == 10
 
-      assert_receive {:batch_handled, :even, messages, %BatchInfo{batcher: :even, size: 5}}
+      assert_receive {:batch_handled, :even, messages,
+                      %BatchInfo{batcher: :even, size: 5, is_full: true}}
                      when length(messages) == 5
 
-      assert_receive {:batch_handled, :even, messages, %BatchInfo{batcher: :even, size: 5}}
+      assert_receive {:batch_handled, :even, messages,
+                      %BatchInfo{batcher: :even, size: 5, is_full: true}}
                      when length(messages) == 5
 
-      assert_receive {:batch_handled, :even, messages, %BatchInfo{batcher: :even, size: 5}}
+      assert_receive {:batch_handled, :even, messages,
+                      %BatchInfo{batcher: :even, size: 5, is_full: true}}
                      when length(messages) == 5
 
-      assert_receive {:batch_handled, :even, messages, %BatchInfo{batcher: :even, size: 5}}
+      assert_receive {:batch_handled, :even, messages,
+                      %BatchInfo{batcher: :even, size: 5, is_full: true}}
                      when length(messages) == 5
 
       refute_received {:batch_handled, _, _}
@@ -1029,8 +1035,12 @@ defmodule BroadwayTest do
          %{broadway: broadway} do
       Broadway.test_batch(broadway, [1, 2, 3, 4, 5], batch_mode: :flush)
 
-      assert_receive {:batch_handled, :odd, messages, _} when length(messages) == 3
-      assert_receive {:batch_handled, :even, messages, _} when length(messages) == 2
+      assert_receive {:batch_handled, :odd, messages, %BatchInfo{is_full: false}}
+                     when length(messages) == 3
+
+      assert_receive {:batch_handled, :even, messages, %BatchInfo{is_full: false}}
+                     when length(messages) == 2
+
       refute_received {:batch_handled, _, _, _}
     end
   end
@@ -1076,8 +1086,11 @@ defmodule BroadwayTest do
       assert_receive {:ack, ^ref, [%{data: 2, batch_key: :even}, %{data: 4, batch_key: :even}],
                       []}
 
-      assert_receive {:batch_handled, :default, %BatchInfo{batch_key: :odd, size: 2}}
-      assert_receive {:batch_handled, :default, %BatchInfo{batch_key: :even, size: 2}}
+      assert_receive {:batch_handled, :default,
+                      %BatchInfo{batch_key: :odd, size: 2, is_full: true}}
+
+      assert_receive {:batch_handled, :default,
+                      %BatchInfo{batch_key: :even, size: 2, is_full: true}}
     end
 
     test "generate batches with the remaining messages after :batch_timeout is reached",


### PR DESCRIPTION
Adding an is_full field to %BatchInfo{} that indicates whether batch is full (:size == batch_size), whether it will be consumed after timeout or not. Discussed in  https://github.com/dashbitco/broadway/issues/253.