### PR TITLE
Fix telemetry event measurements names and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ Broadway v0.7 requires Erlang/OTP 21.3+.
 ### Backwards incompatible changes
 
   * Remove `Broadway.TermStorage` now that we have Broadway topology information on the producer init callback
-  * Rename :events to :messages in batcher telemetry event
-  * Rename :time to :system_time in telemetry event
+  * Rename `:events` to `:messages` in batcher telemetry event
+  * Remove `:time` from "stop" telemetry event measurements
+  * Rename `:time` to `:system_time` in telemetry event measurements
   * Rename `[:broadway, :consumer, *]` to `[:broadway, :batch_processor, *]` in telemetry event
 
 ### Enhancements

--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -556,13 +556,13 @@ defmodule Broadway do
       contains the configuration options that were provided to
       `Broadway.start_link/2`.
 
-      * Measurement: `%{time: System.monotonic_time}`
+      * Measurement: `%{system_time: System.monotonic_time}`
       * Metadata: `%{supervision: pid(), config: keyword()}`
 
     * `[:broadway, :processor, :start]` - Dispatched by a Broadway processor
       before the optional `c:prepare_messages/2`
 
-      * Measurement: `%{time: System.monotonic_time}`
+      * Measurement: `%{system_time: System.monotonic_time}`
       * Metadata:
 
         ```
@@ -579,7 +579,7 @@ defmodule Broadway do
       after `c:prepare_messages/2` and after all `c:handle_message/3` callback
       has been invoked for all individual messages
 
-      * Measurement: `%{time: System.monotonic_time, duration: native_time}`
+      * Measurement: `%{duration: native_time}`
 
       * Metadata:
 
@@ -598,7 +598,7 @@ defmodule Broadway do
     * `[:broadway, :processor, :message, :start]` - Dispatched by a Broadway processor
       before your `c:handle_message/3` callback is invoked
 
-      * Measurement: `%{time: System.monotonic_time}`
+      * Measurement: `%{system_time: System.monotonic_time}`
 
       * Metadata:
 
@@ -615,7 +615,7 @@ defmodule Broadway do
     * `[:broadway, :processor, :message, :stop]` - Dispatched by a Broadway processor
       after your `c:handle_message/3` callback has returned
 
-      * Measurement: `%{time: System.monotonic_time, duration: native_time}`
+      * Measurement: `%{duration: native_time}`
 
       * Metadata:
 
@@ -632,7 +632,7 @@ defmodule Broadway do
     * `[:broadway, :processor, :message, :exception]` - Dispatched by a Broadway processor
       if your `c:handle_message/3` callback encounters an exception
 
-      * Measurement: `%{time: System.monotonic_time, duration: native_time}`
+      * Measurement: `%{duration: native_time}`
 
       * Metadata:
 
@@ -652,7 +652,7 @@ defmodule Broadway do
     * `[:broadway, :batch_processor, :start]` - Dispatched by a Broadway batch processor
       before your `c:handle_batch/4` callback is invoked
 
-      * Measurement: `%{time: System.monotonic_time}`
+      * Measurement: `%{system_time: System.monotonic_time}`
       * Metadata:
 
         ```
@@ -668,7 +668,7 @@ defmodule Broadway do
     * `[:broadway, :batch_processor, :stop]` - Dispatched by a Broadway batch
       processor after your `c:handle_batch/4` callback has returned
 
-      * Measurement: `%{time: System.monotonic_time, duration: native_time}`
+      * Measurement: `%{duration: native_time}`
 
       * Metadata:
 
@@ -686,7 +686,7 @@ defmodule Broadway do
     * `[:broadway, :batcher, :start]` - Dispatched by a Broadway batcher before
       handling events
 
-      * Measurement: `%{time: System.monotonic_time}`
+      * Measurement: `%{system_time: System.monotonic_time}`
       * Metadata:
 
         ```
@@ -701,7 +701,7 @@ defmodule Broadway do
     * `[:broadway, :batcher, :stop]` - Dispatched by a Broadway batcher after
       handling events
 
-      * Measurement: `%{time: System.monotonic_time, duration: native_time}`
+      * Measurement: `%{duration: native_time}`
       * Metadata:
 
       ```
@@ -711,6 +711,11 @@ defmodule Broadway do
           batcher_key: atom
         }
       ```
+
+  Most of the events follow the `:telemetry.span/3` convention for measurements.
+  This means that "start" events have a `system_time` representing the start of
+  that event, and "stop" or "exception" events have the `duration` value.
+
   """
 
   alias Broadway.{BatchInfo, Message, Topology}

--- a/lib/broadway/topology.ex
+++ b/lib/broadway/topology.ex
@@ -180,7 +180,7 @@ defmodule Broadway.Topology do
   end
 
   defp emit_init_event(user_config, supervisor_pid) do
-    measurements = %{time: System.monotonic_time()}
+    measurements = %{system_time: System.monotonic_time()}
 
     metadata = %{
       config: user_config,

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -246,7 +246,7 @@ defmodule BroadwayTest do
       assert get_n_producers(broadway) == 3
       assert length(Broadway.producer_names(broadway)) == 3
 
-      assert_receive {:telemetry_event, [:broadway, :topology, :init], %{},
+      assert_receive {:telemetry_event, [:broadway, :topology, :init], %{system_time: _},
                       %{config: config, supervisor_pid: supervisor_pid}}
                      when is_pid(supervisor_pid)
 
@@ -851,57 +851,88 @@ defmodule BroadwayTest do
       assert_receive {:ack, ^ref, [], [%{status: {:failed, "Failed message"}}]}
       assert_receive {:ack, ^ref, [], [%{status: {:failed, "Failed batcher"}}]}
 
-      assert_receive {:telemetry_event, [:broadway, :processor, :start], %{}, %{}}
+      assert_receive {:telemetry_event, [:broadway, :processor, :start], %{system_time: _}, %{}}
 
-      assert_receive {:telemetry_event, [:broadway, :processor, :message, :start], %{}, %{}}
-      assert_receive {:telemetry_event, [:broadway, :processor, :message, :stop], %{}, %{}}
-      assert_receive {:telemetry_event, [:broadway, :processor, :stop], %{}, metadata}
+      assert_receive {:telemetry_event, [:broadway, :processor, :message, :start],
+                      %{system_time: _}, %{}}
+
+      assert_receive {:telemetry_event, [:broadway, :processor, :message, :stop], %{duration: _},
+                      %{}}
+
+      assert_receive {:telemetry_event, [:broadway, :processor, :stop], %{duration: _}, metadata}
       assert [] = metadata.failed_messages
 
-      assert_receive {:telemetry_event, [:broadway, :processor, :start], %{}, %{}}
-      assert_receive {:telemetry_event, [:broadway, :processor, :message, :start], %{}, %{}}
-      assert_receive {:telemetry_event, [:broadway, :processor, :message, :stop], %{}, %{}}
+      assert_receive {:telemetry_event, [:broadway, :processor, :start], %{system_time: _}, %{}}
 
-      assert_receive {:telemetry_event, [:broadway, :processor, :stop], %{},
+      assert_receive {:telemetry_event, [:broadway, :processor, :message, :start],
+                      %{system_time: _}, %{}}
+
+      assert_receive {:telemetry_event, [:broadway, :processor, :message, :stop], %{duration: _},
+                      %{}}
+
+      assert_receive {:telemetry_event, [:broadway, :processor, :stop], %{duration: _},
                       %{failed_messages: []}}
 
       assert [] = metadata.failed_messages
 
-      assert_receive {:telemetry_event, [:broadway, :processor, :start], %{}, %{}}
-      assert_receive {:telemetry_event, [:broadway, :processor, :message, :start], %{}, %{}}
-      assert_receive {:telemetry_event, [:broadway, :processor, :message, :stop], %{}, %{}}
-      assert_receive {:telemetry_event, [:broadway, :processor, :stop], %{}, metadata}
+      assert_receive {:telemetry_event, [:broadway, :processor, :start], %{system_time: _}, %{}}
+
+      assert_receive {:telemetry_event, [:broadway, :processor, :message, :start],
+                      %{system_time: _}, %{}}
+
+      assert_receive {:telemetry_event, [:broadway, :processor, :message, :stop], %{duration: _},
+                      %{}}
+
+      assert_receive {:telemetry_event, [:broadway, :processor, :stop], %{duration: _}, metadata}
       assert [%{data: :fail}] = metadata.failed_messages
 
-      assert_receive {:telemetry_event, [:broadway, :processor, :start], %{}, %{}}
-      assert_receive {:telemetry_event, [:broadway, :processor, :message, :start], %{}, %{}}
-      assert_receive {:telemetry_event, [:broadway, :processor, :message, :stop], %{}, %{}}
-      assert_receive {:telemetry_event, [:broadway, :processor, :stop], %{}, metadata}
+      assert_receive {:telemetry_event, [:broadway, :processor, :start], %{system_time: _}, %{}}
+
+      assert_receive {:telemetry_event, [:broadway, :processor, :message, :start],
+                      %{system_time: _}, %{}}
+
+      assert_receive {:telemetry_event, [:broadway, :processor, :message, :stop], %{duration: _},
+                      %{}}
+
+      assert_receive {:telemetry_event, [:broadway, :processor, :stop], %{duration: _}, metadata}
       assert [] = metadata.failed_messages
 
-      assert_receive {:telemetry_event, [:broadway, :batcher, :start], %{}, %{messages: [_]}}
-      assert_receive {:telemetry_event, [:broadway, :batcher, :stop], %{}, %{}}
-      assert_receive {:telemetry_event, [:broadway, :batcher, :start], %{}, %{messages: [_]}}
-      assert_receive {:telemetry_event, [:broadway, :batcher, :stop], %{}, %{}}
-      assert_receive {:telemetry_event, [:broadway, :batcher, :start], %{}, %{messages: [_]}}
-      assert_receive {:telemetry_event, [:broadway, :batcher, :stop], %{}, %{}}
+      assert_receive {:telemetry_event, [:broadway, :batcher, :start], %{system_time: _},
+                      %{messages: [_]}}
 
-      assert_receive {:telemetry_event, [:broadway, :batch_processor, :start], %{},
+      assert_receive {:telemetry_event, [:broadway, :batcher, :stop], %{duration: _}, %{}}
+
+      assert_receive {:telemetry_event, [:broadway, :batcher, :start], %{system_time: _},
+                      %{messages: [_]}}
+
+      assert_receive {:telemetry_event, [:broadway, :batcher, :stop], %{duration: _}, %{}}
+
+      assert_receive {:telemetry_event, [:broadway, :batcher, :start], %{system_time: _},
+                      %{messages: [_]}}
+
+      assert_receive {:telemetry_event, [:broadway, :batcher, :stop], %{duration: _}, %{}}
+
+      assert_receive {:telemetry_event, [:broadway, :batch_processor, :start], %{system_time: _},
                       %{messages: [%{data: 1}, %{data: 2}], batch_info: %BatchInfo{}}}
 
-      assert_receive {:telemetry_event, [:broadway, :batch_processor, :stop], %{},
+      assert_receive {:telemetry_event, [:broadway, :batch_processor, :stop], %{duration: _},
                       %{failed_messages: [], batch_info: %BatchInfo{}}}
 
-      assert_receive {:telemetry_event, [:broadway, :batch_processor, :start], %{},
+      assert_receive {:telemetry_event, [:broadway, :batch_processor, :start], %{system_time: _},
                       %{messages: [%{data: :fail_batcher}], batch_info: %BatchInfo{}}}
 
-      assert_receive {:telemetry_event, [:broadway, :batch_processor, :stop], %{},
+      assert_receive {:telemetry_event, [:broadway, :batch_processor, :stop], %{duration: _},
                       %{failed_messages: [%{data: :fail_batcher}], batch_info: %BatchInfo{}}}
 
-      assert_receive {:telemetry_event, [:broadway, :processor, :start], %{}, %{}}
-      assert_receive {:telemetry_event, [:broadway, :processor, :message, :start], %{}, %{}}
-      assert_receive {:telemetry_event, [:broadway, :processor, :message, :exception], %{}, %{}}
-      assert_receive {:telemetry_event, [:broadway, :processor, :stop], %{}, %{}}
+      assert_receive {:telemetry_event, [:broadway, :processor, :start], %{system_time: _}, %{}}
+
+      assert_receive {:telemetry_event, [:broadway, :processor, :message, :start],
+                      %{system_time: _}, %{}}
+
+      assert_receive {:telemetry_event, [:broadway, :processor, :message, :exception],
+                      %{duration: _}, %{}}
+
+      assert_receive {:telemetry_event, [:broadway, :processor, :stop], %{duration: _}, %{}}
       assert_receive {:ack, ^ref, [], [%{status: {:error, _, _}}]}
 
       :telemetry.detach("#{test}")


### PR DESCRIPTION
Since we changed to use `:telemetry.span/3`, the events have now
a different name for the system time field. This change normalizes the
events following the "span" convention.