### PR TITLE
Increase timeout so the CI won't fail easily

### DIFF
--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -2400,10 +2400,10 @@ defmodule BroadwayTest do
 
       send(get_rate_limiter(broadway_name), :reset_limit)
 
-      assert_receive {:handle_message_called, %Broadway.Message{data: 3}, timestamp3}
+      assert_receive {:handle_message_called, %Broadway.Message{data: 3}, timestamp3}, 4_000
 
       assert_receive {:handle_message_called, %Broadway.Message{data: :message_during_cancel},
-                      timestamp_cancel}
+                      timestamp_cancel}, 4_000
 
       assert timestamp_cancel > timestamp1
       assert timestamp3 < timestamp_cancel

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -2403,7 +2403,8 @@ defmodule BroadwayTest do
       assert_receive {:handle_message_called, %Broadway.Message{data: 3}, timestamp3}, 4_000
 
       assert_receive {:handle_message_called, %Broadway.Message{data: :message_during_cancel},
-                      timestamp_cancel}, 4_000
+                      timestamp_cancel},
+                     4_000
 
       assert timestamp_cancel > timestamp1
       assert timestamp3 < timestamp_cancel


### PR DESCRIPTION
Try to fix an intermittent test by increasing the timeout of two
specific "assert_receive" assertions.