### PR TITLE
Ensuring telemetry events are correct when handle_message/3 calls Message.failed/2.

### DIFF
--- a/lib/broadway/topology/processor_stage.ex
+++ b/lib/broadway/topology/processor_stage.ex
@@ -151,15 +151,18 @@ defmodule Broadway.Topology.ProcessorStage do
             context: state.context
           },
           fn ->
-            {processor_key
-             |> module.handle_message(message, context)
-             |> validate_message(batchers),
+            updated_message =
+              processor_key
+              |> module.handle_message(message, context)
+              |> validate_message(batchers)
+
+            {updated_message,
              %{
                processor_key: state.processor_key,
                topology_name: state.topology_name,
                index: state.partition,
                name: state.name,
-               message: message,
+               message: updated_message,
                context: state.context
              }}
           end

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -83,6 +83,10 @@ defmodule BroadwayTest do
   defmodule CustomHandlers do
     use Broadway
 
+    def handle_message(_, %{data: "fail_in_handle_message"} = message, _context) do
+      Broadway.Message.failed(message, "fail_in_handle_message")
+    end
+
     def handle_message(_, message, %{handle_message: handler} = context) do
       handler.(message, context)
     end
@@ -842,7 +846,7 @@ defmodule BroadwayTest do
           nil
         )
 
-      ref = Broadway.test_batch(broadway, [1, 2, :fail, :fail_batcher, :raise])
+      ref = Broadway.test_batch(broadway, [1, 2, :fail, :fail_batcher, :raise, "fail_in_handle_message"])
 
       assert_receive {:batch_handled, [%{data: 1, status: :ok}, %{data: 2, status: :ok}]}
       assert_receive {:batch_handled, [%{data: :fail_batcher, status: :ok}]}
@@ -850,6 +854,7 @@ defmodule BroadwayTest do
       assert_receive {:ack, ^ref, [%{status: :ok}, %{status: :ok}], []}
       assert_receive {:ack, ^ref, [], [%{status: {:failed, "Failed message"}}]}
       assert_receive {:ack, ^ref, [], [%{status: {:failed, "Failed batcher"}}]}
+      assert_receive {:ack, ^ref, [], [%{status: {:failed, "fail_in_handle_message"}}]}
 
       assert_receive {:telemetry_event, [:broadway, :processor, :start], %{system_time: _}, %{}}
 

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -846,7 +846,15 @@ defmodule BroadwayTest do
           nil
         )
 
-      ref = Broadway.test_batch(broadway, [1, 2, :fail, :fail_batcher, :raise, "fail_in_handle_message"])
+      ref =
+        Broadway.test_batch(broadway, [
+          1,
+          2,
+          :fail,
+          :fail_batcher,
+          :raise,
+          "fail_in_handle_message"
+        ])
 
       assert_receive {:batch_handled, [%{data: 1, status: :ok}, %{data: 2, status: :ok}]}
       assert_receive {:batch_handled, [%{data: :fail_batcher, status: :ok}]}


### PR DESCRIPTION
This fixes a bug that was introduced in [this commit](https://github.com/dashbitco/broadway/commit/95d6aeaa9512d7447b8cd0f1e4d50c382dbbf82d). Specifically if `handle_message/3` calls `Broadway.Message.failed/2`, telemetry events do not reflect the failure.