### PR TITLE
#269 set :shuffle_demands_on_first_dispatch to true for DemandDispatcher

### DIFF
--- a/lib/broadway/topology.ex
+++ b/lib/broadway/topology.ex
@@ -277,7 +277,8 @@ defmodule Broadway.Topology do
           {:consumer, nil, :none}
 
         [_] = batchers ->
-          {:producer_consumer, {GenStage.DemandDispatcher, shuffle_demands_on_first_dispatch: true}, batchers}
+          {:producer_consumer,
+           {GenStage.DemandDispatcher, shuffle_demands_on_first_dispatch: true}, batchers}
 
         [_ | _] = batchers ->
           {:producer_consumer,


### PR DESCRIPTION
Using the feature **Shuffle the demands on first dispatch for load balancing across consumers** provided in [PR of GenStage](https://github.com/elixir-lang/gen_stage/pull/277), the issue discussed in #269 can be fixed by turning on the flag `:shuffle_demands_on_first_dispatch`