### PR TITLE
Fix outdated name for BatchProcessor in architecture guide

### DIFF
--- a/guides/internals/architecture.md
+++ b/guides/internals/architecture.md
@@ -73,7 +73,7 @@ is designed as follows:
 ```
 
 
-Both `ProcessorSupervisor` and `ConsumerSupervisor` are set with
+Both `ProcessorSupervisor` and `BatchProcessorSupervisor` are set with
 `max_restarts` to 0. The idea is that if any process fails, we want
 to restart the rest of the tree. Since Broadway callbacks are
 stateless, we can handle errors and provide reports without crashing


### PR DESCRIPTION
The name change on the 1.0.0 release, from `Consumer` to `BatchProcessor`, wasn't applied in the architecture documentation.

PS: I'm assuming that's the case because I haven't seen that term in the illustration and also because this change happened for the metrics' names.