### PR TITLE
Add another clause to handle_no_reply

### DIFF
--- a/lib/broadway/topology/producer_stage.ex
+++ b/lib/broadway/topology/producer_stage.ex
@@ -246,6 +246,10 @@ defmodule Broadway.Topology.ProducerStage do
         {state, messages} = maybe_rate_limit_and_buffer_messages(state, messages)
         {:noreply, messages, %{state | module_state: new_module_state}}
 
+      {:noreply, new_module_state} ->
+        {state, messages} = maybe_rate_limit_and_buffer_messages(state, [])
+        {:noreply, messages, %{state | module_state: new_module_state}}
+
       {:noreply, events, new_module_state, :hibernate} ->
         messages = transform_events(events, transformer)
         {state, messages} = maybe_rate_limit_and_buffer_messages(state, messages)


### PR DESCRIPTION
The Integration tests of the library [BroadwayKafka](https://github.com/dashbitco/broadway_kafka) were failing.

I created the PR https://github.com/dashbitco/broadway_kafka/pull/77 to fix some of the errors, but these adjustments here also seem to be necessary.

When running the integration tests, I was getting this error which says the function `handle_no_reply` don't have a case clause to match.
```elixir
02:05:53.560 [error] GenServer BroadwayKafka.ConsumerTest.MyBroadway.Broadway.Producer_0 terminating
** (CaseClauseError) no case clause matching: {:noreply, %{acks: %{{1, "test", 0} => {[], 0, []}}, allocator_names: {0, [BroadwayKafka.ConsumerTest.MyBroadway.Allocator_processor_default], [BroadwayKafka.ConsumerTest.MyBroadway.Allocator_batcher_consumer_default]}, buffer: {[], []}, client: BroadwayKafka.BrodClient, client_id: BroadwayKafka.ConsumerTest.MyBroadway.Broadway.Producer_0.Client, config: %{client_config: [], fetch_config: %{max_bytes: 10240}, group_config: [offset_commit_policy: :commit_to_kafka_v2, offset_commit_interval_seconds: 1, rejoin_delay_seconds: 2], group_id: "brod_my_group", hosts: [localhost: 9092], offset_commit_on_ack: true, offset_reset_policy: :latest, receive_interval: 100, reconnect_timeout: 1000, topics: ["test"]}, demand: 30, group_coordinator: #PID<0.308.0>, receive_interval: 100, receive_timer: #Reference<0.1922261966.476315655.91186>, reconnect_timeout: 1000, revoke_caller: nil, shutting_down?: false}}
    (broadway 1.0.0) lib/broadway/topology/producer_stage.ex:243: Broadway.Topology.ProducerStage.handle_no_reply/2
    (gen_stage 1.1.1) lib/gen_stage.ex:2108: GenStage.noreply_callback/3
    (stdlib 3.17) gen_server.erl:695: :gen_server.try_dispatch/4
    (stdlib 3.17) gen_server.erl:771: :gen_server.handle_msg/6
    (stdlib 3.17) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Last message: {:EXIT, #PID<0.358.0>, :normal}
State: %{consumers: [{#PID<0.320.0>, #Reference<0.1922261966.476315655.91190>}, {#PID<0.319.0>, #Reference<0.1922261966.476315656.91280>}, {#PID<0.318.0>, #Reference<0.1922261966.476315656.91276>}], module: BroadwayKafka.Producer, module_state: %{acks: %{{1, "test", 0} => {[], 0, []}}, allocator_names: {0, [BroadwayKafka.ConsumerTest.MyBroadway.Allocator_processor_default], [BroadwayKafka.ConsumerTest.MyBroadway.Allocator_batcher_consumer_default]}, buffer: {[], []}, client: BroadwayKafka.BrodClient, client_id: BroadwayKafka.ConsumerTest.MyBroadway.Broadway.Producer_0.Client, config: %{client_config: [], fetch_config: %{max_bytes: 10240}, group_config: [offset_commit_policy: :commit_to_kafka_v2, offset_commit_interval_seconds: 1, rejoin_delay_seconds: 2], group_id: "brod_my_group", hosts: [localhost: 9092], offset_commit_on_ack: true, offset_reset_policy: :latest, receive_interval: 100, reconnect_timeout: 1000, topics: ["test"]}, demand: 30, group_coordinator: #PID<0.308.0>, receive_interval: 100, receive_timer: #Reference<0.1922261966.476315655.91186>, reconnect_timeout: 1000, revoke_caller: nil, shutting_down?: false}, rate_limiting: nil, transformer: nil}

```

after adding this new appropriate case clause, the tests passed correctly.