### PR TITLE
Support :fan_in producer

### DIFF
--- a/lib/broadway/topology/fan_in_producer.ex
+++ b/lib/broadway/topology/fan_in_producer.ex
@@ -1,0 +1,23 @@
+defmodule Broadway.Topology.FanInProducer do
+  @behaviour Broadway.Producer
+  use GenStage
+
+  @impl true
+  def init(_args) do
+    {:producer, %{}}
+  end
+
+  @impl true
+  def handle_demand(_incoming_demand, state) do
+    {:noreply, [], state}
+  end
+
+  @impl true
+  def handle_call({:push_messages, messages}, _from, state) do
+    {:reply, :reply, messages, state}
+  end
+
+  def process_name(broadway_name, base_name) do
+    :"#{broadway_name}.Broadway.FanIn#{base_name}"
+  end
+end

--- a/lib/broadway/topology/producer_stage.ex
+++ b/lib/broadway/topology/producer_stage.ex
@@ -29,7 +29,15 @@ defmodule Broadway.Topology.ProducerStage do
 
   @impl true
   def init({args, index}) do
-    {module, arg} = args[:module]
+    {module, arg} =
+      case args[:module] do
+        {:fan_in, opts} ->
+          {Broadway.Topology.FanInProducer, opts}
+
+        _ ->
+          args[:module]
+      end
+
     transformer = args[:transformer]
     dispatcher = args[:dispatcher]
     rate_limiter = args[:rate_limiter]


### PR DESCRIPTION
The implementation is a bit different than the [issue](https://github.com/dashbitco/broadway/issues/198)

A `FanInProducer` is provided if user specify `:fan_in` as I think instead of putting special logic to handle fan-in scenario, it would be more natural on using this special producer.  Maybe for back-off support in the future.

Or my consideration is not well-thought enough?  Please advice.