### PR TITLE
Add `message` argument to the batcher example

### DIFF
--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -289,7 +289,8 @@ defmodule Broadway do
 
         def handle_message(_, message, _) do
           if special?(message) do
-            Broadway.Message.put_batcher(:special)
+            message
+            |> Broadway.Message.put_batcher(:special)
           else
             message
           end


### PR DESCRIPTION
`Broadway.Message.put_batcher/2` requires `message` as the first argument.