### PR TITLE
fix: documentation example to configure BroadwayEctoSandbox

### DIFF
--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -506,7 +506,7 @@ defmodule Broadway do
             [:broadway, :batch_processor, :start],
           ]
 
-          :telemetry.attach_many({__MODULE__, repo}, events, &handle_event/4, %{repo: repo})
+          :telemetry.attach_many({__MODULE__, repo}, events, &__MODULE__.handle_event/4, %{repo: repo})
         end
 
         def handle_event(_event_name, _event_measurement, %{messages: messages}, %{repo: repo}) do


### PR DESCRIPTION
It fixes the next telemetry warning:

```
Function passed as a handler with ID {App.BroadwayEctoSandbox, App.Repo} is local function.
This mean that it is either anonymous function or capture of function without module specified. That may cause performance penalty when calling such handler. For more details see note in `telemetry:attach/4` documentation.

https://hexdocs.pm/telemetry/telemetry.html#attach-4
```