### PR TITLE
Update documentation about the topology init event

### DIFF
--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -617,7 +617,7 @@ defmodule Broadway do
       `Broadway.start_link/2`.
 
       * Measurement: `%{system_time: integer}`
-      * Metadata: `%{supervision: pid, config: keyword}`
+      * Metadata: `%{supervisor_pid: pid, config: keyword}`
 
     * `[:broadway, :processor, :start]` - Dispatched by a Broadway processor
       before the optional `c:prepare_messages/2`


### PR DESCRIPTION
There is a bit of misleading documentation in the telemetry section, where the `[:broadway, :topology, :init]` event is said to receive `%{supervision: pid, config: keyword}` as metadata.

A test at <https://github.com/dashbitco/broadway/blob/v1.0.3/test/broadway_test.exs#L254> in fact asserts that the correct key is `:supervisor_pid`.

Here is the fix to the documentation.