### PR TITLE
Change the typespec of Broadway.Message.failed/2

### DIFF
--- a/lib/broadway/message.ex
+++ b/lib/broadway/message.ex
@@ -24,7 +24,7 @@ defmodule Broadway.Message do
           batch_mode: :bulk | :flush,
           status:
             :ok
-            | {:failed, reason :: binary}
+            | {:failed, reason :: term}
             | {:throw | :error | :exit, term, Exception.stacktrace()}
         }
 
@@ -135,7 +135,7 @@ defmodule Broadway.Message do
   Failing a message does not emit any log but it does trigger the
   `c:Broadway.handle_failed/2` callback.
   """
-  @spec failed(message :: Message.t(), reason :: binary) :: Message.t()
+  @spec failed(message :: Message.t(), reason :: term) :: Message.t()
   def failed(%Message{} = message, reason) do
     %Message{message | status: {:failed, reason}}
   end


### PR DESCRIPTION
At work we use `failed/2` with tuples to facilitate pattern matching within the `handle_failed/2` callback such as:

```elixir
def dispatch(message) do
  case dispatch_email(message) do
    ...

    {:error, reason} -> 
      Message.failed(message, {:email_dispatch, reason})
  end
end
```

```elixir
def handle_failed(messages, context) do
  Enum.map(messages, fn
    ...

    %Message{status: {:failed, {:email_dispatch, reason}}} = message ->
      Logger.error(" ... ")
      Message.configure_ack(message, on_failure: :noop)
  end)
end
```

In our tests we make use of [Hammox](https://hexdocs.pm/hammox/Hammox.html) to mock functions such as `dispatch`, but such tests fail with a `Hammox.TypeMatchError` because the `Broadway.Message` typespec requires the failed reason to be a binary.

So I propose the typespec be updated to allow any type of reason.