### PR TITLE
Skip `c:handle_message/3` for messages failed in `c:prepare_messages/2`

### DIFF
--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -816,8 +816,8 @@ defmodule Broadway do
 
   The length of the list of messages received by this callback is based on
   the `min_demand`/`max_demand` configuration in the processor. This callback
-  must always return all messages it receives, as `c:handle_message/3` is still
-  called individually for each message afterwards.
+  must always return all messages it receives. `c:handle_message/3` will be
+  called for each non-failed message afterwards.
   """
   @callback prepare_messages(messages :: [Message.t()], context :: term) :: [Message.t()]
 

--- a/lib/broadway/topology/processor_stage.ex
+++ b/lib/broadway/topology/processor_stage.ex
@@ -111,12 +111,10 @@ defmodule Broadway.Topology.ProcessorStage do
 
     if function_exported?(module, :prepare_messages, 2) do
       try do
-        prepared_messages =
-          messages
-          |> module.prepare_messages(context)
-          |> validate_prepared_messages(messages)
-
-        {prepared_messages, []}
+        messages
+        |> module.prepare_messages(context)
+        |> validate_prepared_messages(messages)
+        |> Enum.split_with(&match?(%{status: :ok}, &1))
       catch
         kind, reason ->
           reason = Exception.normalize(kind, reason, __STACKTRACE__)


### PR DESCRIPTION
Before all messages from `c:prepare_messages/2` were passed along to `c:handle_message/3` unless an exception was raised. Now selectively failed messages will skip `c:handle_message/3`.

This could be useful when preloading data, but there aren't matching records for each message.