### PR TITLE
Improve error on bad handle_batch/4 return

### DIFF
--- a/lib/broadway/topology/batch_processor_stage.ex
+++ b/lib/broadway/topology/batch_processor_stage.ex
@@ -126,4 +126,13 @@ defmodule Broadway.Topology.BatchProcessorStage do
   defp split_by_status([%Message{} = message | rest], successful, failed, count) do
     split_by_status(rest, successful, [message | failed], count + 1)
   end
+
+  defp split_by_status([other | _rest], _successful, _failed, _count) do
+    raise "handle_batch/4 must return a list of %Broadway.Message{} structs, " <>
+            "but one element was: #{inspect(other)}"
+  end
+
+  defp split_by_status(other, _successful, _failed, _count) do
+    raise "handle_batch/4 must return a list of %Broadway.Message{} structs, got: #{inspect(other)}"
+  end
 end


### PR DESCRIPTION
Without this, the error is:

```
10:10:34.307 [error] ** (FunctionClauseError) no function clause matching in Broadway.Topology.BatchProcessorStage.split_by_status/4
    (broadway 1.0.6) lib/broadway/topology/batch_processor_stage.ex:118: Broadway.Topology.BatchProcessorStage.split_by_status(:ok, [], [], 0)
    (broadway 1.0.6) lib/broadway/topology/batch_processor_stage.ex:104: Broadway.Topology.BatchProcessorStage.handle_batch/4
    (broadway 1.0.6) lib/broadway/topology/batch_processor_stage.ex:58: anonymous fn/5 in Broadway.Topology.BatchProcessorStage.handle_events/3
    (telemetry 1.2.1) /Users/andrea/Library/Caches/mix/installs/elixir-1.14.2-erts-13.0.4/a2f9ee168726c26df78129abc19240bd/deps/telemetry/src/telemetry.erl:321: :telemetry.span/3
    (gen_stage 1.2.1) lib/gen_stage.ex:2578: GenStage.consumer_dispatch/6
    (stdlib 4.0.1) gen_server.erl:1120: :gen_server.try_dispatch/4
    (stdlib 4.0.1) gen_server.erl:1197: :gen_server.handle_msg/6
    (stdlib 4.0.1) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
```