### PR TITLE
docs: Update lib version in readme to 1.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add `:broadway` to the list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:broadway, "~> 1.0"}
+    {:broadway, "~> 1.0.7"}
   ]
 end
 ```


### PR DESCRIPTION
Hi, I'm opening this PR just to update the version of lib dependency in the readme to the latest version.