### PR TITLE
Provide more clarity on the length of list in `c:prepare_messages/2`

### DIFF
--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -814,12 +814,12 @@ defmodule Broadway do
   by `c:handle_message/3`. For example, if you need to query the database,
   instead of doing it once per message, you can do it on this callback.
 
-  The length of the list of messages received by this callback is based on
-  the `min_demand`/`max_demand` configuration in the processor.  That is, this
-  will determine how frequently more items are requested. The length of the
-  list of messages ultimately depends on the producer. For example, the
-  `BroadwayRabbitMQ.Producer` is a streaming producer and it is more likely for
-  messages to appear as they are pushed. 
+  The length of the list of messages received by this callback is often based
+  on the `min_demand`/`max_demand` configuration in the processor but ultimately
+  it depends on the producer and the frequency data arrives. A pipeline that
+  receives one message per minute will most likely emit single element lists.
+  Producers which are push-based, rather than pull-based, such as
+  `BroadwayRabbitMQ.Producer`, are more likely to send messages as they appear.
 
   This callback must always return all messages it receives, as
   `c:handle_message/3` is still called individually for each message afterwards.

--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -815,9 +815,14 @@ defmodule Broadway do
   instead of doing it once per message, you can do it on this callback.
 
   The length of the list of messages received by this callback is based on
-  the `min_demand`/`max_demand` configuration in the processor. This callback
-  must always return all messages it receives, as `c:handle_message/3` is still
-  called individually for each message afterwards.
+  the `min_demand`/`max_demand` configuration in the processor.  That is, this
+  will determine how frequently more items are requested. The length of the
+  list of messages ultimately depends on the producer. For example, the
+  `BroadwayRabbitMQ.Producer` is a streaming producer and it is more likely for
+  messages to appear as they are pushed. 
+
+  This callback must always return all messages it receives, as
+  `c:handle_message/3` is still called individually for each message afterwards.
   """
   @callback prepare_messages(messages :: [Message.t()], context :: term) :: [Message.t()]
 


### PR DESCRIPTION
This really confused me! I couldn't figure out why, no matter what I did with `min_demand` and `max_demand`, I would always get a single message in `c:prepare_messages/2`. I'm using the `RabbitMQ` producer. I asked [on the Elixir Forum](https://elixirforum.com/t/help-with-tuning-data-flow-in-broadway-c-prepare-messages-2-question/61049/4). I think this explains it a little more clearly so the next person doesn't get confused like me :). Very open to rewording to make it even clearer.