### PR TITLE
feat: refactor persistent term usage to behaviour

### DIFF
--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -607,6 +607,16 @@ defmodule Broadway do
   > Those issues happen regardless of Broadway and solutions to said
   > problems almost always need to be addressed outside of Broadway too.
 
+  ## Configuration Storage
+
+  Broadway comes with two configuration storage options:
+
+  - `Broadway.ConfigStorage.PersistentTerm`
+  - `Broadway.ConfigStorage.Ets`
+
+  `Broadway.ConfigStorage.PersistentTerm` is used by default.
+
+
   ## Telemetry
 
   Broadway currently exposes following Telemetry events:

--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -793,7 +793,7 @@ defmodule Broadway do
 
   """
 
-  alias Broadway.{BatchInfo, Message, Topology}
+  alias Broadway.{BatchInfo, Message, Topology, ConfigStorage.PersistentTerm}
   alias NimbleOptions.ValidationError
 
   @typedoc """
@@ -1144,7 +1144,9 @@ defmodule Broadway do
   @doc since: "1.0.0"
   @spec all_running() :: [name()]
   def all_running do
-    for {{Broadway, name}, %Broadway.Topology{}} <- :persistent_term.get(),
+    config_storage = Application.get_env(Broadway, :config_storage, PersistentTerm)
+
+    for name <- config_storage.list(),
         (try do
            GenServer.whereis(name)
          rescue

--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -793,7 +793,7 @@ defmodule Broadway do
 
   """
 
-  alias Broadway.{BatchInfo, Message, Topology, ConfigStorage.PersistentTerm}
+  alias Broadway.{BatchInfo, Message, Topology, ConfigStorage}
   alias NimbleOptions.ValidationError
 
   @typedoc """
@@ -1144,7 +1144,7 @@ defmodule Broadway do
   @doc since: "1.0.0"
   @spec all_running() :: [name()]
   def all_running do
-    config_storage = Application.get_env(Broadway, :config_storage, PersistentTerm)
+    config_storage = ConfigStorage.get_module()
 
     for name <- config_storage.list(),
         (try do

--- a/lib/broadway/config_storage.ex
+++ b/lib/broadway/config_storage.ex
@@ -30,6 +30,9 @@ defmodule Broadway.ConfigStorage do
 
   @optional_callbacks setup: 0
 
+  @doc """
+  Retrieves the configured module based on the `:config_storage` key.
+  """
   @spec get_module() :: module()
   def get_module() do
     Application.get_env(Broadway, :config_storage, PersistentTerm)
@@ -39,6 +42,9 @@ defmodule Broadway.ConfigStorage do
     end
   end
 
+  @doc """
+  Retrieves any options set on the `:config_storage` key.
+  """
   @spec get_options() :: keyword()
   def get_options() do
     Application.get_env(Broadway, :config_storage, PersistentTerm)

--- a/lib/broadway/config_storage.ex
+++ b/lib/broadway/config_storage.ex
@@ -1,4 +1,13 @@
 defmodule Broadway.ConfigStorage do
+  @moduledoc """
+  Configuration storage behaviour that allows swapping out configuration storage options.
+  """
+
+  @doc """
+  Optional setup for the configuration storage
+  """
+  @callback setup() :: :ok
+
   @doc """
   Lists all broadway names in the config storage
   """
@@ -18,4 +27,24 @@ defmodule Broadway.ConfigStorage do
   Deletes a configuration from the underlying storage
   """
   @callback delete(server :: term()) :: boolean()
+
+  @optional_callbacks setup: 0
+
+  @spec get_module() :: module()
+  def get_module() do
+    Application.get_env(Broadway, :config_storage, PersistentTerm)
+    |> case do
+      {mod, _opts} -> mod
+      mod -> mod
+    end
+  end
+
+  @spec get_options() :: keyword()
+  def get_options() do
+    Application.get_env(Broadway, :config_storage, PersistentTerm)
+    |> case do
+      {_mod, opts} when is_list(opts) -> opts
+      _mod -> []
+    end
+  end
 end

--- a/lib/broadway/config_storage.ex
+++ b/lib/broadway/config_storage.ex
@@ -1,0 +1,21 @@
+defmodule Broadway.ConfigStorage do
+  @doc """
+  Lists all broadway names in the config storage
+  """
+  @callback list() :: [term()]
+
+  @doc """
+  Puts the given key value pair in the underlying storage.
+  """
+  @callback put(server :: term(), value :: %Broadway.Topology{}) :: term()
+
+  @doc """
+  Retrieves a configuration from the underlying storage
+  """
+  @callback get(server :: term()) :: term()
+
+  @doc """
+  Deletes a configuration from the underlying storage
+  """
+  @callback delete(server :: term()) :: boolean()
+end

--- a/lib/broadway/config_storage.ex
+++ b/lib/broadway/config_storage.ex
@@ -1,7 +1,6 @@
 defmodule Broadway.ConfigStorage do
-  @moduledoc """
-  Configuration storage behaviour that allows swapping out configuration storage options.
-  """
+  @moduledoc false
+  alias Broadway.ConfigStorage.{Ets, PersistentTerm}
 
   @doc """
   Optional setup for the configuration storage
@@ -35,9 +34,10 @@ defmodule Broadway.ConfigStorage do
   """
   @spec get_module() :: module()
   def get_module() do
-    Application.get_env(Broadway, :config_storage, PersistentTerm)
+    Application.get_env(Broadway, :config_storage, :persistent_term)
     |> case do
-      {mod, _opts} -> mod
+      :ets -> Ets
+      :persistent_term -> PersistentTerm
       mod -> mod
     end
   end
@@ -47,10 +47,6 @@ defmodule Broadway.ConfigStorage do
   """
   @spec get_options() :: keyword()
   def get_options() do
-    Application.get_env(Broadway, :config_storage, PersistentTerm)
-    |> case do
-      {_mod, opts} when is_list(opts) -> opts
-      _mod -> []
-    end
+    Application.get_env(Broadway, :config_storage_opts) || []
   end
 end

--- a/lib/broadway/config_storage/ets.ex
+++ b/lib/broadway/config_storage/ets.ex
@@ -1,4 +1,33 @@
 defmodule Broadway.ConfigStorage.Ets do
+  @moduledoc """
+  An ETS-backed configuration storage. Only use this if performance improvements over the default `:persistent_term`-based storage is needed.
+
+  To use this configuration storage option, set your application config.exs as so:
+
+  ```elixir
+  config Broadway, config_storage: Broadway.ConfigStorage.Ets
+  ```
+
+  To pass options, use a tuple with a keyword list as so:
+
+  ```elixir
+  config Broadway, config_storage: {Broadway.ConfigStorage.Ets, table_name: :my_table}
+  ```
+
+  Default table is `:broadway_configs`.
+
+  Accepted options:
+  - `:table_name` - configure the table name.
+
+  ## Performance Improvements
+  `:persistent_term` will trigger a global GC on each `put` or `erase`. For situations where there are a large number of dynamically created Broadway pipelines that are created or removed, this may result in the global GC being triggered multiple times. If there is a large number of processes, this may cause the system to be less responsive until all heaps have been scanned.
+
+  As `Broadway.ConfigStorage.PersistentTerm` does not perform an erase when the Broadway server process goes down, it may result in memory buildup over time within the `:persistent_term` hash table, especially when dynamic names are used for the Broadway servers.
+
+  Furthermore, the speed of storing and updating using `:persistent_term` is proportional to the number of already-created terms in the hash table, as the hash table (and term) is copied.
+
+  Using `Broadway.ConfigStorage.Ets` will allow for a large number of Broadway server configurations to be stored and fetched without the associated performance tradeoffs that `:persistent_term` has.
+  """
   alias Broadway.ConfigStorage
   @behaviour ConfigStorage
 

--- a/lib/broadway/config_storage/ets.ex
+++ b/lib/broadway/config_storage/ets.ex
@@ -1,0 +1,45 @@
+defmodule Broadway.ConfigStorage.Ets do
+  alias Broadway.ConfigStorage
+  @behaviour ConfigStorage
+
+  @default_table :broadway_configs
+
+  def default_table(), do: @default_table
+
+  @impl ConfigStorage
+  def setup do
+    if :undefined == :ets.whereis(table()) do
+      :ets.new(table(), [:named_table, :public, :set])
+    end
+
+    :ok
+  end
+
+  @impl ConfigStorage
+  def list do
+    :ets.select(table(), [{{:"$1", :_}, [], [:"$1"]}])
+  end
+
+  @impl ConfigStorage
+  def get(server) do
+    case :ets.match(table(), {server, :"$1"}) do
+      [[topology]] -> topology
+      _ -> nil
+    end
+  end
+
+  @impl ConfigStorage
+  def put(server, topology) do
+    :ets.insert(table(), {server, topology})
+  end
+
+  @impl ConfigStorage
+  def delete(server) do
+    :ets.delete(table(), server)
+  end
+
+  defp table() do
+    opts = ConfigStorage.get_options()
+    Keyword.get(opts, :table_name, @default_table)
+  end
+end

--- a/lib/broadway/config_storage/ets.ex
+++ b/lib/broadway/config_storage/ets.ex
@@ -9,7 +9,7 @@ defmodule Broadway.ConfigStorage.Ets do
   @impl ConfigStorage
   def setup do
     if :undefined == :ets.whereis(table()) do
-      :ets.new(table(), [:named_table, :public, :set])
+      :ets.new(table(), [:named_table, :public, :set, {:read_concurrency, true}])
     end
 
     :ok

--- a/lib/broadway/config_storage/ets.ex
+++ b/lib/broadway/config_storage/ets.ex
@@ -1,33 +1,5 @@
 defmodule Broadway.ConfigStorage.Ets do
-  @moduledoc """
-  An ETS-backed configuration storage. Only use this if performance improvements over the default `:persistent_term`-based storage is needed.
-
-  To use this configuration storage option, set your application config.exs as so:
-
-  ```elixir
-  config Broadway, config_storage: Broadway.ConfigStorage.Ets
-  ```
-
-  To pass options, use a tuple with a keyword list as so:
-
-  ```elixir
-  config Broadway, config_storage: {Broadway.ConfigStorage.Ets, table_name: :my_table}
-  ```
-
-  Default table is `:broadway_configs`.
-
-  Accepted options:
-  - `:table_name` - configure the table name.
-
-  ## Performance Improvements
-  `:persistent_term` will trigger a global GC on each `put` or `erase`. For situations where there are a large number of dynamically created Broadway pipelines that are created or removed, this may result in the global GC being triggered multiple times. If there is a large number of processes, this may cause the system to be less responsive until all heaps have been scanned.
-
-  As `Broadway.ConfigStorage.PersistentTerm` does not perform an erase when the Broadway server process goes down, it may result in memory buildup over time within the `:persistent_term` hash table, especially when dynamic names are used for the Broadway servers.
-
-  Furthermore, the speed of storing and updating using `:persistent_term` is proportional to the number of already-created terms in the hash table, as the hash table (and term) is copied.
-
-  Using `Broadway.ConfigStorage.Ets` will allow for a large number of Broadway server configurations to be stored and fetched without the associated performance tradeoffs that `:persistent_term` has.
-  """
+  @moduledoc false
   alias Broadway.ConfigStorage
   @behaviour ConfigStorage
 

--- a/lib/broadway/config_storage/persistent_term.ex
+++ b/lib/broadway/config_storage/persistent_term.ex
@@ -1,0 +1,31 @@
+defmodule Broadway.ConfigStorage.PersistentTerm do
+  @behaviour Broadway.ConfigStorage
+
+  @impl Broadway.ConfigStorage
+  def list do
+    for {{Broadway, name}, %Broadway.Topology{}} <- :persistent_term.get() do
+      name
+    end
+  end
+
+  @impl Broadway.ConfigStorage
+  def get(server) do
+    :persistent_term.get({Broadway, server}, nil)
+  end
+
+  @impl Broadway.ConfigStorage
+  def put(server, topology) do
+    :persistent_term.put({Broadway, server}, topology)
+  end
+
+  @impl Broadway.ConfigStorage
+  def delete(_server) do
+    # We don't delete from persistent term on purpose. Since the process is
+    # named, we can assume it does not start dynamically, so it will either
+    # restart or the amount of memory it uses is negligibla to justify the
+    # process purging done by persistent_term. If the repo is restarted and
+    # stores the same metadata, then no purging happens either.
+    # :persistent_term.erase({Broadway, server})
+    true
+  end
+end

--- a/lib/broadway/config_storage/persistent_term.ex
+++ b/lib/broadway/config_storage/persistent_term.ex
@@ -2,6 +2,17 @@ defmodule Broadway.ConfigStorage.PersistentTerm do
   @behaviour Broadway.ConfigStorage
 
   @impl Broadway.ConfigStorage
+  def setup do
+    unless Code.ensure_loaded?(:persistent_term) do
+      require Logger
+      Logger.error("Broadway requires Erlang/OTP 21.3+")
+      raise "Broadway requires Erlang/OTP 21.3+"
+    end
+
+    :ok
+  end
+
+  @impl Broadway.ConfigStorage
   def list do
     for {{Broadway, name}, %Broadway.Topology{}} <- :persistent_term.get() do
       name

--- a/lib/broadway/config_storage/persistent_term.ex
+++ b/lib/broadway/config_storage/persistent_term.ex
@@ -1,4 +1,16 @@
 defmodule Broadway.ConfigStorage.PersistentTerm do
+  @moduledoc """
+  A `:persistent_term` backed configuration storage.
+
+  This configuration storage is used by default.
+
+  ```elixir
+  config Broadway, config_storage: Broadway.ConfigStorage.PersistentTerm
+  ```
+
+  Configurations are not deleted when the process goes down, so as to avoid a global GC.
+
+  """
   @behaviour Broadway.ConfigStorage
 
   @impl Broadway.ConfigStorage

--- a/lib/broadway/config_storage/persistent_term.ex
+++ b/lib/broadway/config_storage/persistent_term.ex
@@ -1,16 +1,5 @@
 defmodule Broadway.ConfigStorage.PersistentTerm do
-  @moduledoc """
-  A `:persistent_term` backed configuration storage.
-
-  This configuration storage is used by default.
-
-  ```elixir
-  config Broadway, config_storage: Broadway.ConfigStorage.PersistentTerm
-  ```
-
-  Configurations are not deleted when the process goes down, so as to avoid a global GC.
-
-  """
+  @moduledoc false
   @behaviour Broadway.ConfigStorage
 
   @impl Broadway.ConfigStorage

--- a/test/broadway/config_storage_test.exs
+++ b/test/broadway/config_storage_test.exs
@@ -1,0 +1,37 @@
+defmodule Broadway.ConfigStorageTest do
+  use ExUnit.Case, async: false
+  alias Broadway.ConfigStorage.Ets
+
+  setup do
+    prev = Application.get_env(Broadway, :config_storage)
+
+    on_exit(fn ->
+      Application.put_env(Broadway, :config_storage, prev)
+    end)
+  end
+
+  test "ets default options" do
+    Application.put_env(Broadway, :config_storage, Ets)
+    Ets.setup()
+    assert [] = Ets.list()
+    assert Ets.put("some name", %Broadway.Topology{})
+    assert ["some name"] = Ets.list()
+    assert %Broadway.Topology{} = Ets.get("some name")
+    assert :ets.info(Ets.default_table(), :size) == 1
+    Ets.delete("some name")
+    assert :ets.info(Ets.default_table(), :size) == 0
+  end
+
+  test "ets custom name" do
+    Application.put_env(Broadway, :config_storage, {Ets, table_name: :my_table})
+    Ets.setup()
+    assert :ets.info(:my_table, :size) == 0
+    assert [] = Ets.list()
+    assert Ets.put("some name", %Broadway.Topology{})
+    assert ["some name"] = Ets.list()
+    assert %Broadway.Topology{} = Ets.get("some name")
+    assert :ets.info(:my_table, :size) == 1
+    Ets.delete("some name")
+    assert :ets.info(:my_table, :size) == 0
+  end
+end

--- a/test/broadway/config_storage_test.exs
+++ b/test/broadway/config_storage_test.exs
@@ -4,14 +4,16 @@ defmodule Broadway.ConfigStorageTest do
 
   setup do
     prev = Application.get_env(Broadway, :config_storage)
+    prev_opts = Application.get_env(Broadway, :config_storage_opts)
 
     on_exit(fn ->
       Application.put_env(Broadway, :config_storage, prev)
+      Application.put_env(Broadway, :config_storage_opts, prev_opts)
     end)
   end
 
   test "ets default options" do
-    Application.put_env(Broadway, :config_storage, Ets)
+    Application.put_env(Broadway, :config_storage, :ets)
     Ets.setup()
     assert [] = Ets.list()
     assert Ets.put("some name", %Broadway.Topology{})
@@ -23,7 +25,8 @@ defmodule Broadway.ConfigStorageTest do
   end
 
   test "ets custom name" do
-    Application.put_env(Broadway, :config_storage, {Ets, table_name: :my_table})
+    Application.put_env(Broadway, :config_storage, :ets)
+    Application.put_env(Broadway, :config_storage_opts, table_name: :my_table)
     Ets.setup()
     assert :ets.info(:my_table, :size) == 0
     assert [] = Ets.list()


### PR DESCRIPTION
This PR adds in an ETS configuration storage option, for #342 .

Our use case has many dynamically-created Broadway servers (each with different non-static names). This results in global GC getting triggered. Although https://github.com/dashbitco/broadway/commit/fb69a7a291877f5d3ed5e593db25d442aff90b56 has some improvements, it is insufficient for our situation.

If we were to continue using persistent term using the above mentioned change, it will result in large buildup in the hash table over time. As time to update/store the term is proportional to hash table size, resulting in degrading storage speeds over time. In our case, the memory buildup over time may also be non-negligible. 

However, without the above change (where the persistent term is not cleaned up), it will result in the GC getting triggered each time the server goes down (due to our autoscaling logic).

Switching over to `:ets` based storage would avoid the GC-ing issues.