### PR TITLE
fix: ensure config storage is loaded

### DIFF
--- a/lib/broadway/topology.ex
+++ b/lib/broadway/topology.ex
@@ -50,7 +50,7 @@ defmodule Broadway.Topology do
 
     config_storage = ConfigStorage.get_module()
 
-    if function_exported?(config_storage, :setup, 0) do
+    if Code.ensure_loaded?(config_storage) and function_exported?(config_storage, :setup, 0) do
       config_storage.setup()
     end
 


### PR DESCRIPTION
Seems like `function_exported/2` doesn't return true as the module isn't loaded at runtime.