### PR TITLE
fix: add fullsweep_after to batcher spec

### DIFF
--- a/lib/broadway/topology.ex
+++ b/lib/broadway/topology.ex
@@ -374,7 +374,7 @@ defmodule Broadway.Topology do
         concurrency: options[:concurrency]
       ] ++ options
 
-    opts = [name: name]
+    opts = start_options(name, options)
 
     spec = %{
       start: {BatcherStage, :start_link, [args, opts]},


### PR DESCRIPTION
This PR adds in correct start options for the batcher spec, properly propagating the start options.