### PR TITLE
Minor documentation edits and one `mix format` edit

### DIFF
--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -968,7 +968,7 @@ defmodule Broadway do
   It expects:
 
     * `messages` is the list of messages that failed. All messages passed in the same
-      call to `c:handle_failed/3` will come from the same processing stage.
+      call to `c:handle_failed/2` will come from the same processing stage.
 
     * `context` is the user-defined data structure passed to `start_link/2`.
 

--- a/lib/broadway/config_storage/persistent_term.ex
+++ b/lib/broadway/config_storage/persistent_term.ex
@@ -4,7 +4,7 @@ defmodule Broadway.ConfigStorage.PersistentTerm do
 
   @impl true
   def setup do
-    if !Code.ensure_loaded?(:persistent_term) do
+    if not Code.ensure_loaded?(:persistent_term) do
       require Logger
       Logger.error("Broadway requires Erlang/OTP 21.3+")
       raise "Broadway requires Erlang/OTP 21.3+"

--- a/lib/broadway/config_storage/persistent_term.ex
+++ b/lib/broadway/config_storage/persistent_term.ex
@@ -4,7 +4,7 @@ defmodule Broadway.ConfigStorage.PersistentTerm do
 
   @impl true
   def setup do
-    unless Code.ensure_loaded?(:persistent_term) do
+    if !Code.ensure_loaded?(:persistent_term) do
       require Logger
       Logger.error("Broadway requires Erlang/OTP 21.3+")
       raise "Broadway requires Erlang/OTP 21.3+"

--- a/lib/broadway/producer.ex
+++ b/lib/broadway/producer.ex
@@ -18,8 +18,8 @@ defmodule Broadway.Producer do
   ## Injected Broadway configuration
 
   If `options` is a keyword list, Broadway injects a `:broadway` option
-  into such keyword list. This option contains the configuration for the
-  complete Broadway topology (see `Broadway.start_link/2`. For example,
+  into the keyword list. This option contains the configuration for the
+  complete Broadway topology (see `Broadway.start_link/2`). For example,
   you can use `options[:broadway][:name]` to uniquely identify the topology.
 
   The `:broadway` configuration also has an `:index` key. This

--- a/lib/broadway/producer.ex
+++ b/lib/broadway/producer.ex
@@ -42,8 +42,9 @@ defmodule Broadway.Producer do
 
   You should generally modify `Broadway.Message` structs by using the functions
   in the `Broadway.Message` module. However, if you are implementing your
-  own producer, you **can manipulate** some of the struct's fields directly,
-  such as:
+  own producer, you **can manipulate** some of the struct's fields directly.
+
+  These fields are:
 
     * `:data` (required) - the data of the message. Even though the function
       `Broadway.Message.put_data/2` exists, when creating a `%Broadway.Message{}`

--- a/lib/broadway/producer.ex
+++ b/lib/broadway/producer.ex
@@ -71,7 +71,7 @@ defmodule Broadway.Producer do
 
   The goal of this callback is to manipulate the general topology options,
   if necessary at all, and introduce any new child specs that will be
-  started **before** the producers supervisor in Broadway's supervision tree.
+  started **before** the producer's supervisor in Broadway's supervision tree.
   Broadway's supervision tree is a `rest_for_one` supervisor (see the documentation
   for `Supervisor`), which means that if the children returned from this callback
   crash they will bring down the rest of the pipeline before being restarted.
@@ -86,8 +86,8 @@ defmodule Broadway.Producer do
   is the list of child specs to be started under Broadway's supervision tree.
   `updated_options` is a potentially-updated list of Broadway options
   that will be used instead of the ones passed to `Broadway.start_link/2`. This can be
-  used to modify the characteristics of the Broadway topology to accommodated
-  for the children started here.
+  used to modify the characteristics of the Broadway topology to accommodate
+  the children started here.
 
   ## Examples
 

--- a/lib/broadway/producer.ex
+++ b/lib/broadway/producer.ex
@@ -100,6 +100,7 @@ defmodule Broadway.Producer do
            children = [
              {DynamicSupervisor, strategy: :one_for_one, name: MyApp.DynamicSupervisor}
            ]
+            updated_options = put_in(broadway_options, [:producer, :rate_limiting], [interval: 1000, allowed_messages: 10])
 
            {children, updated_options}
         end

--- a/lib/broadway/producer.ex
+++ b/lib/broadway/producer.ex
@@ -102,7 +102,7 @@ defmodule Broadway.Producer do
              {DynamicSupervisor, strategy: :one_for_one, name: MyApp.DynamicSupervisor}
            ]
 
-           {children, broadway_options}
+           {children, updated_options}
         end
       end
 

--- a/lib/broadway/producer.ex
+++ b/lib/broadway/producer.ex
@@ -70,7 +70,7 @@ defmodule Broadway.Producer do
 
   The goal of this callback is to manipulate the general topology options,
   if necessary at all, and introduce any new child specs that will be
-  started **before** the producer's supervisor in Broadway's supervision tree.
+  started **before** the producers' supervisor in Broadway's supervision tree.
   Broadway's supervision tree is a `rest_for_one` supervisor (see the documentation
   for `Supervisor`), which means that if the children returned from this callback
   crash they will bring down the rest of the pipeline before being restarted.

--- a/lib/broadway/producer.ex
+++ b/lib/broadway/producer.ex
@@ -42,9 +42,8 @@ defmodule Broadway.Producer do
 
   You should generally modify `Broadway.Message` structs by using the functions
   in the `Broadway.Message` module. However, if you are implementing your
-  own producer, you **can manipulate** some of the struct's fields directly.
-
-  These fields are:
+  own producer, you **can manipulate** some of the struct's fields directly,
+  such as:
 
     * `:data` (required) - the data of the message. Even though the function
       `Broadway.Message.put_data/2` exists, when creating a `%Broadway.Message{}`

--- a/lib/broadway/producer.ex
+++ b/lib/broadway/producer.ex
@@ -24,7 +24,7 @@ defmodule Broadway.Producer do
 
   The `:broadway` configuration also has an `:index` key. This
   is the index of the producer in its supervision tree (starting
-  from `0`). This allows a features such having even producers
+  from `0`). This allows features such as having even producers
   connect to some server while odd producers connect to another.
 
   If `options` is any other term, it is passed as is to the `c:GenStage.init/1`


### PR DESCRIPTION
edited some grammatical issues i read across
 and an example in the documentation seemed up for being relabeled 
 and when I ran "mix format", it removed an "unless"
 and mix docs through an error on a callback's arity so I fixed that