### PR TITLE
feat: include producer metadata in per-message events

### DIFF
--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -714,7 +714,8 @@ defmodule Broadway do
           name: atom,
           index: non_neg_integer,
           message: Broadway.Message.t,
-          telemetry_span_context: reference
+          telemetry_span_context: reference,
+          producer: {atom, list}
         }
         ```
 
@@ -732,7 +733,8 @@ defmodule Broadway do
           name: atom,
           index: non_neg_integer,
           message: Broadway.Message.t,
-          telemetry_span_context: reference
+          telemetry_span_context: reference,
+          producer: {atom, list}
         }
         ```
 
@@ -753,7 +755,8 @@ defmodule Broadway do
           kind: kind,
           reason: reason,
           stacktrace: stacktrace,
-          telemetry_span_context: reference
+          telemetry_span_context: reference,
+          producer: {atom, list}
         }
         ```
 

--- a/lib/broadway/topology/processor_stage.ex
+++ b/lib/broadway/topology/processor_stage.ex
@@ -164,7 +164,8 @@ defmodule Broadway.Topology.ProcessorStage do
             index: state.partition,
             name: state.name,
             message: message,
-            context: state.context
+            context: state.context,
+            producer: state.producer
           },
           fn ->
             updated_message =
@@ -179,7 +180,8 @@ defmodule Broadway.Topology.ProcessorStage do
                index: state.partition,
                name: state.name,
                message: updated_message,
-               context: state.context
+               context: state.context,
+               producer: state.producer
              }}
           end
         )

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -946,10 +946,10 @@ defmodule BroadwayTest do
       assert_receive {:telemetry_event, [:broadway, :processor, :start], %{system_time: _}, %{}}
 
       assert_receive {:telemetry_event, [:broadway, :processor, :message, :start],
-                      %{system_time: _}, %{}}
+                      %{system_time: _}, %{producer: {ManualProducer, []}}}
 
       assert_receive {:telemetry_event, [:broadway, :processor, :message, :stop], %{duration: _},
-                      %{}}
+                      %{producer: {ManualProducer, []}}}
 
       assert_receive {:telemetry_event, [:broadway, :processor, :stop], %{duration: _}, metadata}
       assert [] = metadata.failed_messages
@@ -1022,7 +1022,7 @@ defmodule BroadwayTest do
                       %{system_time: _}, %{}}
 
       assert_receive {:telemetry_event, [:broadway, :processor, :message, :exception],
-                      %{duration: _}, %{}}
+                      %{duration: _}, %{producer: {ManualProducer, []}}}
 
       assert_receive {:telemetry_event, [:broadway, :processor, :stop], %{duration: _}, %{}}
       assert_receive {:ack, ^ref, [], [%{status: {:error, _, _}}]}


### PR DESCRIPTION
- Per-message telemetry events were missing the \`producer\` field that batch-level events already had (added in #308), making it impossible to correlate per-message spans back to their source producer
- Without producer metadata, consumers of per-message telemetry events cannot populate OTel semantic convention attributes like \`messaging.system\` (derived from the producer module) and \`messaging.destination.name\` (from producer opts), which are required for meaningful span scoping in multi-producer pipelines