### PR TITLE
chore: Add Sobelow security scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,11 @@ jobs:
       - run: mix compile --warnings-as-errors
         if: ${{ matrix.lint }}
 
+      - run: mix sobelow --conf
+        env:
+          MIX_ENV: dev
+        if: ${{ matrix.lint }}
+
       - run: mix test
         if: ${{!matrix.coverage}}
 

--- a/.sobelow-conf
+++ b/.sobelow-conf
@@ -1,0 +1,12 @@
+[
+  verbose: false,
+  private: true,
+  skip: true,
+  router: nil,
+  exit: :low,
+  format: "txt",
+  out: nil,
+  threshold: :low,
+  ignore_files: [],
+  version: false,
+]

--- a/lib/broadway/topology.ex
+++ b/lib/broadway/topology.ex
@@ -484,6 +484,8 @@ defmodule Broadway.Topology do
     end
   end
 
+  # Only used while building the application-defined topology, before any messages are processed.
+  # sobelow_skip ["DOS.BinToAtom"]
   defp default_process_name(broadway_name, base_name) when is_atom(broadway_name) do
     :"#{broadway_name}.Broadway.#{base_name}"
   end

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,8 @@ defmodule Broadway.MixProject do
       # Dev/test dependencies.
       {:castore, "~> 1.0", only: :test},
       {:ex_doc, ">= 0.19.0", only: :docs},
-      {:excoveralls, "~> 0.18.0", only: :test}
+      {:excoveralls, "~> 0.18.0", only: :test},
+      {:sobelow, ">= 0.14.0", only: [:dev], runtime: false}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -10,5 +10,6 @@
   "makeup_erlang": {:hex, :makeup_erlang, "1.0.3", "4252d5d4098da7415c390e847c814bad3764c94a814a0b4245176215615e1035", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "953297c02582a33411ac6208f2c6e55f0e870df7f80da724ed613f10e6706afd"},
   "nimble_options": {:hex, :nimble_options, "1.1.1", "e3a492d54d85fc3fd7c5baf411d9d2852922f66e69476317787a7b2bb000a61b", [:mix], [], "hexpm", "821b2470ca9442c4b6984882fe9bb0389371b8ddec4d45a9504f00a66f650b44"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.2", "8efba0122db06df95bfaa78f791344a89352ba04baedd3849593bfce4d0dc1c6", [:mix], [], "hexpm", "4b21398942dda052b403bbe1da991ccd03a053668d147d53fb8c4e0efe09c973"},
+  "sobelow": {:hex, :sobelow, "0.14.1", "2f81e8632f15574cba2402bcddff5497b413c01e6f094bc0ab94e83c2f74db81", [:mix], [{:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "8fac9a2bd90fdc4b15d6fca6e1608efb7f7c600fa75800813b794ee9364c87f2"},
   "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
 }


### PR DESCRIPTION
In response to the rash of CVEs from vulnerabilities that static analysis can detect (see [the EEF's list of most common weaknesses](https://cna.erlef.org/common-weaknesses), of which uncontrolled resource consumption like as atom table exhaustion is number 1), I thought it might be valuable to add Sobelow scanning to the project. It didn't find anything actionable (yay! 🎉), but I figured it might still be good to have it running in CI so that future potential vulnerabilities can be called out.