### PR TITLE
docs: add link to off_broadway_pulsar

### DIFF
--- a/guides/examples/introduction.md
+++ b/guides/examples/introduction.md
@@ -35,6 +35,7 @@ The following Off-Broadway libraries are available (feel free to send a PR addin
   * [off_broadway_emqtt](https://github.com/intility/off_broadway_emqtt): [Guide](https://hexdocs.pm/off_broadway_emqtt/)
   * [off_broadway_kafka](https://github.com/bbalser/off_broadway_kafka): [Guide](https://hexdocs.pm/off_broadway_kafka/)
   * [off_broadway_memory](https://github.com/elliotekj/off_broadway_memory): [Guide](https://hexdocs.pm/off_broadway_memory/)
+  * [off_broadway_pulsar](https://github.com/efcasado/off_broadway_pulsar): [Guide](https://hexdocs.pm/off_broadway_pulsar/)
   * [off_broadway_redis](https://github.com/amokan/off_broadway_redis): [Guide](https://hexdocs.pm/off_broadway_redis/)
   * [off_broadway_redis_stream](https://github.com/akash-akya/off_broadway_redis_stream): [Guide](https://hexdocs.pm/off_broadway_redis_stream/)
   * [off_broadway_splunk](https://github.com/intility/off_broadway_splunk): [Guide](https://hexdocs.pm/off_broadway_splunk/)


### PR DESCRIPTION
### Description

Some months ago, we built an [Apache Pulsar](https://pulsar.apache.org/) producer for Broadway (and a companion Pulsar client), namely [off_broadway_pulsar](https://github.com/efcasado/off_broadway_pulsar) (and [pulsar-elixir](https://github.com/efcasado/pulsar-elixir)). We thought others in the community may find it useful too.

We built these libraries out of necessity. We are heavily invested in Apache Pulsar, and when we started our Elixir journey, we noticed that the Pulsar tooling in the Elixir ecosystem was not as mature as the tooling available for Kafka.

We have been running both projects in production for several months now, and we finally feel more comfortable sharing them more broadly 😄 So far, our focus has been on replacing our [Benthos](https://github.com/redpanda-data/benthos)-based data ingestion pipelines with Broadway, and we're excited to see what other use cases we (and the wider community) will find for them.

We thought adding `off_broadway_pulsar` to [the official list of non-official Broadway producers](https://broadway.hexdocs.pm/introduction.html#non-official-off-broadway-producers) would be a good start.